### PR TITLE
fix: Client version in dispatched event now shows React SDK version instead of underlying Javscript SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Javascript SDK Client version was being sent in dispatched events. Changed it to send React SDK client version.
+
 ## [1.0.0] - September 27th, 2019
 
 Initial release

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -79,12 +79,13 @@ describe('ReactSDKClient', () => {
     expect(createInstanceSpy.mock.results[0].value).toBe(instance.client)
   })
 
-  it('adds clientEngine react-sdk the config, and passed the config to createInstance', () => {
+  it('adds react-sdk clientEngine and clientVersion to the config, and passed the config to createInstance', () => {
     createInstance(config)
     expect(createInstanceSpy).toBeCalledTimes(1)
     expect(createInstanceSpy).toBeCalledWith({
       ...config,
       clientEngine: 'react-sdk',
+      clientVersion: '1.0.0',
     })
   })
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -33,6 +33,7 @@ export type OnReadyResult = {
 }
 
 const REACT_SDK_CLIENT_ENGINE = 'react-sdk'
+const REACT_SDK_CLIENT_VERSION = '1.0.0'
 
 export interface ReactSDKClient extends optimizely.Client {
   user: UserContext
@@ -146,11 +147,12 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
 
     this.userPromiseResovler = () => {}
 
-    const configWithClientEngine = {
+    const configWithClientInfo = {
       ...config,
       clientEngine: REACT_SDK_CLIENT_ENGINE,
+      clientVersion: REACT_SDK_CLIENT_VERSION,
     }
-    this._client = optimizely.createInstance(configWithClientEngine)
+    this._client = optimizely.createInstance(configWithClientInfo)
 
     this.userPromise = new Promise(resolve => {
       this.userPromiseResovler = resolve


### PR DESCRIPTION
## Summary
Javascript SDK Client version was being sent in dispatched events. Changed it to send React SDK client version.

## Test Plan
Manually tested thoroughly