### PR TITLE
Export context consumer/provider pair to enable unit testing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export { OptimizelyContextConsumer, OptimizelyContextProvider } from './Context'
 export { OptimizelyProvider } from './Provider'
 export { OptimizelyFeature } from './Feature'
 export { withOptimizely, WithOptimizelyProps, WithoutOptimizelyProps } from './withOptimizely'


### PR DESCRIPTION
Is there any reason this change wasn't adopted before the migration to v1.0.0?

https://github.com/optimizely/fullstack-labs/pull/42/files

We are pretty much blocked on unit testing any component that contains a render component from the Optimizely React SDK. It would also be really helpful if there was some brief documentation on how to integrate unit testing with the React SDK.