### PR TITLE
chore: Update optimizely-sdk to 3.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@optimizely/js-sdk-logging": "^0.1.0",
-    "@optimizely/optimizely-sdk": "3.3.0",
+    "@optimizely/optimizely-sdk": "3.3.2",
     "hoist-non-react-statics": "^3.3.0",
     "prop-types": "^15.6.2",
     "react-broadcast": "0.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,10 +55,10 @@
   dependencies:
     uuid "^3.3.2"
 
-"@optimizely/optimizely-sdk@3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-3.3.0.tgz#77e578877b7d80d16b453b312216561b56ee192b"
-  integrity sha512-ct034R9qOhCjxnQnVpvcvuZKNOJsWs1pliGS8fEud3re3NvincnOCUwkv91yv8cPaySJeT2bKLIg5pocmlh2Aw==
+"@optimizely/optimizely-sdk@3.3.2":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-3.3.2.tgz#fa60a82b5f32ad1336d806d5a88710a53f842382"
+  integrity sha512-4SwucN9/3ISI68tLrP9WMRR6oeRmX+VuOKlTu3BXSZdzbGQIeDYINftmsQgDVTCK3+jjf9GCt8F5AFz5cvfG/Q==
   dependencies:
     "@optimizely/js-sdk-datafile-manager" "^0.4.0"
     "@optimizely/js-sdk-event-processor" "^0.3.0"


### PR DESCRIPTION
Update optimizely-sdk dependency to 3.3.2. This brings in the React Native default logger fix and the fix for error message logged upon bucketed into unallocated space.