### PR TITLE
maintanance (OptimizelyProvider): Replace react-broadcast with the native React context API

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,11 +543,6 @@ License: [MIT](https://github.com/piotrwitek/utility-types/blob/master/LICENSE)
 Copyright &copy; 2010-2016 Robert Kieffer and other contributors
 License: [MIT](https://github.com/kelektiv/node-uuid/blob/master/LICENSE.md)
 
-[**warning**](https://github.com/BerkeleyTrue/warning)  
-Copyright &copy; 2013-present, Facebook, Inc.
-License: [MIT](https://github.com/BerkeleyTrue/warning/blob/master/LICENSE.md)
-
-
 
 To regenerate the dependencies use by this package, run the following command:
 

--- a/README.md
+++ b/README.md
@@ -523,10 +523,6 @@ License: [MIT](https://github.com/taylorhakes/promise-polyfill/blob/master/LICEN
 Copyright &copy; 2013-present, Facebook, Inc.
 License: [MIT](https://github.com/facebook/prop-types/blob/master/LICENSE)
 
-[**react-broadcast**](https://github.com/ReactTraining/react-broadcast)  
-Copyright &copy; React Training 2016-2018
-License: [MIT](https://github.com/ReactTraining/react-broadcast/blob/master/LICENSE)
-
 [**react-is**](https://github.com/facebook/react)  
 Copyright &copy; Facebook, Inc. and its affiliates.
 License: [MIT](https://github.com/facebook/react/blob/master/LICENSE)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@optimizely/optimizely-sdk": "3.3.2",
     "hoist-non-react-statics": "^3.3.0",
     "prop-types": "^15.6.2",
-    "react-broadcast": "0.7.1",
     "utility-types": "^2.1.0"
   },
   "peerDependencies": {
@@ -44,7 +43,6 @@
     "@types/jest": "^23.3.12",
     "@types/prop-types": "^15.5.6",
     "@types/react": "^16.7.18",
-    "@types/react-broadcast": "^0.6.1",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.7.1",
     "jest": "^23.6.0",

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -13,10 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// @ts-ignore
 import { createContext } from 'react'
+import { ReactSDKClient } from './client'
 
-const { Consumer, Provider } = createContext({
+export interface OptimizelyContext {
+  optimizely: ReactSDKClient | null,
+  isServerSide: boolean,
+  timeout: number | undefined,
+}
+
+const { Consumer, Provider } = createContext<OptimizelyContext>({
   optimizely: null,
   isServerSide: false,
   timeout: 0,

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 // @ts-ignore
-import { createContext } from 'react-broadcast'
+import { createContext } from 'react'
 
 const { Consumer, Provider } = createContext({
   optimizely: null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export { OptimizelyContextConsumer, OptimizelyContextProvider } from './Context'
 export { OptimizelyProvider } from './Provider'
 export { OptimizelyFeature } from './Feature'
 export { withOptimizely, WithOptimizelyProps, WithoutOptimizelyProps } from './withOptimizely'

--- a/src/withOptimizely.tsx
+++ b/src/withOptimizely.tsx
@@ -16,7 +16,7 @@
 import * as React from 'react'
 import { Subtract } from 'utility-types'
 
-import { OptimizelyContextConsumer } from './Context'
+import { OptimizelyContextConsumer, OptimizelyContext } from './Context'
 import { ReactSDKClient } from './client'
 import { hoistStaticsAndForwardRefs } from './utils'
 
@@ -45,11 +45,7 @@ export function withOptimizely<P extends WithOptimizelyProps, R>(
       // https://github.com/microsoft/TypeScript/issues/28884
       return (
         <OptimizelyContextConsumer>
-          {(value: {
-            optimizely: ReactSDKClient
-            isServerSide: boolean
-            timeout: number | undefined
-          }) => (
+          {(value: OptimizelyContext) => (
             <Component
               {...rest as P}
               optimizelyReadyTimeout={value.timeout}

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,13 +120,6 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
   integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
 
-"@types/react-broadcast@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@types/react-broadcast/-/react-broadcast-0.6.1.tgz#8b1bd9d37ff1db783db875228fefd26b6fbdfa90"
-  integrity sha512-L5SENk1DYPNw5jaozAmx4ZoFl3zAlPqdDyTgq68S45ZZsL0YFimGSmqKo1NoBgqR+tpx6hTyZIeJ8p20U6rimw==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react@*", "@types/react@^16.7.18":
   version "16.8.19"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.19.tgz#629154ef05e2e1985cdde94477deefd823ad9be3"
@@ -3258,7 +3251,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -3330,14 +3323,6 @@ rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-broadcast@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/react-broadcast/-/react-broadcast-0.7.1.tgz#732c1f4d3c9dbb9dbf0b92540c7c2490fb746dfb"
-  integrity sha512-GhYhRBSSwys6dP++mlC2BNlKMgDfUCKAmOB7eyvgatsWk4TKY+sWVmkGkblP+QduHSBF/Rc+yTE2fZR+8+7Brw==
-  dependencies:
-    prop-types "^15.6.0"
-    warning "^3.0.0"
 
 react-dom@^16.7.0:
   version "16.8.6"
@@ -4269,13 +4254,6 @@ walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
-
-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
-  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
-  dependencies:
-    loose-envify "^1.0.0"
 
 watch@~0.18.0:
   version "0.18.0"


### PR DESCRIPTION
## Summary

Replace usage of `react-broadcast` with the native React Context API.

The `createContext` API appears to be identical in both cases, so this is just a simple swap with adding a type for the `OptimizelyContext` state.

More here: https://reactjs.org/docs/context.html#reactcreatecontext
