### PR TITLE
feat (Context): Export entire OptimizelyContext object

### DIFF
--- a/src/Context.ts
+++ b/src/Context.ts
@@ -16,17 +16,17 @@
 import { createContext } from 'react'
 import { ReactSDKClient } from './client'
 
-export interface OptimizelyContext {
+export interface OptimizelyContextInterface {
   optimizely: ReactSDKClient | null,
   isServerSide: boolean,
   timeout: number | undefined,
 }
 
-const { Consumer, Provider } = createContext<OptimizelyContext>({
+export const OptimizelyContext = createContext<OptimizelyContextInterface>({
   optimizely: null,
   isServerSide: false,
   timeout: 0,
 })
 
-export const OptimizelyContextConsumer = Consumer
-export const OptimizelyContextProvider = Provider
+export const OptimizelyContextConsumer = OptimizelyContext.Consumer
+export const OptimizelyContextProvider = OptimizelyContext.Provider

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { OptimizelyContextConsumer, OptimizelyContextProvider } from './Context'
+export { OptimizelyContext, OptimizelyContextConsumer, OptimizelyContextProvider } from './Context'
 export { OptimizelyProvider } from './Provider'
 export { OptimizelyFeature } from './Feature'
 export { withOptimizely, WithOptimizelyProps, WithoutOptimizelyProps } from './withOptimizely'

--- a/src/withOptimizely.tsx
+++ b/src/withOptimizely.tsx
@@ -16,7 +16,7 @@
 import * as React from 'react'
 import { Subtract } from 'utility-types'
 
-import { OptimizelyContextConsumer, OptimizelyContext } from './Context'
+import { OptimizelyContextConsumer, OptimizelyContextInterface } from './Context'
 import { ReactSDKClient } from './client'
 import { hoistStaticsAndForwardRefs } from './utils'
 
@@ -45,7 +45,7 @@ export function withOptimizely<P extends WithOptimizelyProps, R>(
       // https://github.com/microsoft/TypeScript/issues/28884
       return (
         <OptimizelyContextConsumer>
-          {(value: OptimizelyContext) => (
+          {(value: OptimizelyContextInterface) => (
             <Component
               {...rest as P}
               optimizelyReadyTimeout={value.timeout}


### PR DESCRIPTION
## Summary

In preparation for adding support for hooks, export the entire Optimizely Context object.

This PR leaves in the existing Consumer/Provider export pair for backward compatibility.

Partially addresses #6 