### PR TITLE
enhancement (<OptimizelyFeature>): Convert to functional component that uses useFeature hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Refactored `<OptimizelyFeature>` to a functional component that uses the `useFeature` hook under the hood. See [#32](https://github.com/optimizely/react-sdk/pull/32) for more details.
+
 ### New Features
 
 - Added `useFeature` hook
@@ -14,9 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Enhancements
 
-- Exposed the entire context object used by 
+- Exposed the entire context object used by `<OptimizelyProvider>`.
   - Enables support for using APIs which require passing reference to a context object, like `useContext`. [#27](https://github.com/optimizely/react-sdk/pull/27) for more details.
-
 
 ## [1.2.0-alpha.1] - March 5th, 2020
 

--- a/src/Feature.spec.tsx
+++ b/src/Feature.spec.tsx
@@ -81,8 +81,8 @@ describe('<OptimizelyFeature>', () => {
 
       component.update();
 
-      expect(optimizelyMock.isFeatureEnabled).toHaveBeenCalledWith('feature1');
-      expect(optimizelyMock.getFeatureVariables).toHaveBeenCalledWith('feature1');
+      expect(optimizelyMock.isFeatureEnabled).toHaveBeenCalledWith('feature1', undefined, undefined);
+      expect(optimizelyMock.getFeatureVariables).toHaveBeenCalledWith('feature1', undefined, undefined);
       expect(component.text()).toBe('true|bar');
     });
 
@@ -99,14 +99,14 @@ describe('<OptimizelyFeature>', () => {
 
       // while it's waiting for onReady()
       expect(component.text()).toBe('');
-      resolver.resolve({ sucess: true });
+      resolver.resolve({ success: true });
 
       await optimizelyMock.onReady();
 
       component.update();
 
-      expect(optimizelyMock.isFeatureEnabled).toHaveBeenCalledWith('feature1');
-      expect(optimizelyMock.getFeatureVariables).toHaveBeenCalledWith('feature1');
+      expect(optimizelyMock.isFeatureEnabled).toHaveBeenCalledWith('feature1', undefined, undefined);
+      expect(optimizelyMock.getFeatureVariables).toHaveBeenCalledWith('feature1', undefined, undefined);
       expect(component.text()).toBe('true|bar');
     });
 
@@ -123,14 +123,14 @@ describe('<OptimizelyFeature>', () => {
 
       // while it's waiting for onReady()
       expect(component.text()).toBe('');
-      resolver.resolve({ sucess: true });
+      resolver.resolve({ success: true });
 
       await optimizelyMock.onReady();
 
       component.update();
 
-      expect(optimizelyMock.isFeatureEnabled).toHaveBeenCalledWith('feature1');
-      expect(optimizelyMock.getFeatureVariables).toHaveBeenCalledWith('feature1');
+      expect(optimizelyMock.isFeatureEnabled).toHaveBeenCalledWith('feature1', undefined, undefined);
+      expect(optimizelyMock.getFeatureVariables).toHaveBeenCalledWith('feature1', undefined, undefined);
       expect(component.text()).toBe('true|bar');
     });
 
@@ -148,14 +148,14 @@ describe('<OptimizelyFeature>', () => {
 
         // while it's waiting for onReady()
         expect(component.text()).toBe('');
-        resolver.resolve({ sucess: true });
+        resolver.resolve({ success: true });
 
         await optimizelyMock.onReady();
 
         component.update();
 
-        expect(optimizelyMock.isFeatureEnabled).toHaveBeenCalledWith('feature1');
-        expect(optimizelyMock.getFeatureVariables).toHaveBeenCalledWith('feature1');
+        expect(optimizelyMock.isFeatureEnabled).toHaveBeenCalledWith('feature1', undefined, undefined);
+        expect(optimizelyMock.getFeatureVariables).toHaveBeenCalledWith('feature1', undefined, undefined);
         expect(component.text()).toBe('true|bar');
 
         const updateFn = (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1];
@@ -190,14 +190,14 @@ describe('<OptimizelyFeature>', () => {
 
         // while it's waiting for onReady()
         expect(component.text()).toBe('');
-        resolver.resolve({ sucess: true });
+        resolver.resolve({ success: true });
 
         await optimizelyMock.onReady();
 
         component.update();
 
-        expect(optimizelyMock.isFeatureEnabled).toHaveBeenCalledWith('feature1');
-        expect(optimizelyMock.getFeatureVariables).toHaveBeenCalledWith('feature1');
+        expect(optimizelyMock.isFeatureEnabled).toHaveBeenCalledWith('feature1', undefined, undefined);
+        expect(optimizelyMock.getFeatureVariables).toHaveBeenCalledWith('feature1', undefined, undefined);
         expect(component.text()).toBe('true|bar');
 
         const updateFn = (optimizelyMock.onUserUpdate as jest.Mock).mock.calls[0][0];
@@ -233,14 +233,14 @@ describe('<OptimizelyFeature>', () => {
 
         // while it's waiting for onReady()
         expect(component.text()).toBe('');
-        resolver.resolve({ sucess: false, reason: 'fail' });
+        resolver.resolve({ success: false, reason: 'fail', dataReadyPromise: Promise.resolve() });
 
-        await optimizelyMock.onReady();
+        await optimizelyMock.onReady().then(res => res.dataReadyPromise);
 
         component.update();
 
-        expect(optimizelyMock.isFeatureEnabled).toHaveBeenCalledWith('feature1');
-        expect(optimizelyMock.getFeatureVariables).toHaveBeenCalledWith('feature1');
+        expect(optimizelyMock.isFeatureEnabled).toHaveBeenCalledWith('feature1', undefined, undefined);
+        expect(optimizelyMock.getFeatureVariables).toHaveBeenCalledWith('feature1', undefined, undefined);
         expect(component.text()).toBe('true|bar');
       });
     });

--- a/src/Feature.tsx
+++ b/src/Feature.tsx
@@ -26,10 +26,15 @@ export interface FeatureProps extends WithOptimizelyProps {
   autoUpdate?: boolean;
   overrideUserId?: string;
   overrideAttributes?: UserAttributes;
-  children: (isEnabled: boolean, variables: VariableValuesObject) => React.ReactNode;
+  children: (
+    isEnabled: boolean,
+    variables: VariableValuesObject,
+    clientReady: boolean,
+    didTimeout: boolean
+  ) => React.ReactNode;
 }
 
-const FeatureComponent = (props: FeatureProps): any => {
+const FeatureComponent: React.FunctionComponent<FeatureProps> = props => {
   const { feature, timeout, autoUpdate, children, overrideUserId, overrideAttributes } = props;
   const [isEnabled, variables, clientReady, didTimeout] = useFeature(
     feature,
@@ -42,7 +47,9 @@ const FeatureComponent = (props: FeatureProps): any => {
     return null;
   }
 
-  return children(isEnabled, variables);
+  // Wrap the return value here in a Fragment to please the HOC's expected React.ComponentType
+  // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
+  return <>{children(isEnabled, variables, clientReady, didTimeout)}</>;
 };
 
 export const OptimizelyFeature = withOptimizely(FeatureComponent);

--- a/src/Feature.tsx
+++ b/src/Feature.tsx
@@ -14,148 +14,35 @@
  * limitations under the License.
  */
 import * as React from 'react';
-import { withOptimizely, WithOptimizelyProps } from './withOptimizely';
-import { VariableValuesObject, OnReadyResult, DEFAULT_ON_READY_TIMEOUT } from './client';
-import { getLogger } from '@optimizely/js-sdk-logging';
+import { UserAttributes } from '@optimizely/optimizely-sdk';
 
-const logger = getLogger('<OptimizelyFeature>');
+import { VariableValuesObject } from './client';
+import { useFeature } from './hooks';
+import { withOptimizely, WithOptimizelyProps } from './withOptimizely';
 
 export interface FeatureProps extends WithOptimizelyProps {
-  // TODO add support for overrideUserId
   feature: string;
   timeout?: number;
   autoUpdate?: boolean;
+  overrideUserId?: string;
+  overrideAttributes?: UserAttributes;
   children: (isEnabled: boolean, variables: VariableValuesObject) => React.ReactNode;
 }
 
-export interface FeatureState {
-  canRender: boolean;
-  isEnabled: boolean;
-  variables: VariableValuesObject;
-}
+const FeatureComponent = (props: FeatureProps): any => {
+  const { feature, timeout, autoUpdate, children, overrideUserId, overrideAttributes } = props;
+  const [isEnabled, variables, clientReady, didTimeout] = useFeature(
+    feature,
+    { timeout, autoUpdate },
+    { overrideUserId, overrideAttributes }
+  );
 
-class FeatureComponent extends React.Component<FeatureProps, FeatureState> {
-  private optimizelyNotificationId?: number;
-  private unregisterUserListener: () => void;
-  private autoUpdate = false;
-
-  constructor(props: FeatureProps) {
-    super(props);
-
-    this.unregisterUserListener = () => {};
-
-    const { autoUpdate, isServerSide, optimizely, feature } = props;
-    this.autoUpdate = !!autoUpdate;
-    if (isServerSide) {
-      if (optimizely === null) {
-        throw new Error('optimizely prop must be supplied');
-      }
-      const isEnabled = optimizely.isFeatureEnabled(feature);
-      const variables = optimizely.getFeatureVariables(feature);
-      this.state = {
-        canRender: true,
-        isEnabled,
-        variables,
-      };
-    } else {
-      this.state = {
-        canRender: false,
-        isEnabled: false,
-        variables: {},
-      };
-    }
+  if (!clientReady && !didTimeout) {
+    // Only block rendering while were waiting for the client within the allowed timeout.
+    return null;
   }
 
-  componentDidMount() {
-    const { feature, optimizely, optimizelyReadyTimeout, isServerSide, timeout } = this.props;
-    if (!optimizely) {
-      throw new Error('optimizely prop must be supplied');
-    }
-
-    if (isServerSide) {
-      return;
-    }
-
-    // allow overriding of the ready timeout via the `timeout` prop passed to <Experiment />
-    const finalReadyTimeout: number | undefined = timeout !== undefined ? timeout : optimizelyReadyTimeout;
-
-    optimizely.onReady({ timeout: finalReadyTimeout }).then((res: OnReadyResult) => {
-      if (res.success) {
-        logger.info('feature="%s" successfully rendered for user="%s"', feature, optimizely.user.id);
-      } else {
-        logger.info(
-          'feature="%s" could not be checked before timeout of %sms, reason="%s" ',
-          feature,
-          timeout === undefined ? DEFAULT_ON_READY_TIMEOUT : timeout,
-          res.reason || ''
-        );
-      }
-
-      const isEnabled = optimizely.isFeatureEnabled(feature);
-      const variables = optimizely.getFeatureVariables(feature);
-      this.setState({
-        canRender: true,
-        isEnabled,
-        variables,
-      });
-
-      if (this.autoUpdate) {
-        this.setupAutoUpdateListeners();
-      }
-    });
-  }
-
-  setupAutoUpdateListeners() {
-    const { optimizely, feature } = this.props;
-    if (optimizely === null) {
-      return;
-    }
-
-    this.optimizelyNotificationId = optimizely.notificationCenter.addNotificationListener(
-      'OPTIMIZELY_CONFIG_UPDATE',
-      () => {
-        logger.info('OPTIMIZELY_CONFIG_UPDATE, re-evaluating feature="%s" for user="%s"', feature, optimizely.user.id);
-        const isEnabled = optimizely.isFeatureEnabled(feature);
-        const variables = optimizely.getFeatureVariables(feature);
-        this.setState({
-          isEnabled,
-          variables,
-        });
-      }
-    );
-
-    this.unregisterUserListener = optimizely.onUserUpdate(() => {
-      logger.info('User update, re-evaluating feature="%s" for user="%s"', feature, optimizely.user.id);
-      const isEnabled = optimizely.isFeatureEnabled(feature);
-      const variables = optimizely.getFeatureVariables(feature);
-      this.setState({
-        isEnabled,
-        variables,
-      });
-    });
-  }
-
-  componentWillUnmount() {
-    const { optimizely, isServerSide } = this.props;
-    if (isServerSide || !this.autoUpdate) {
-      return;
-    }
-    if (optimizely && this.optimizelyNotificationId) {
-      optimizely.notificationCenter.removeNotificationListener(this.optimizelyNotificationId);
-    }
-    this.unregisterUserListener();
-  }
-
-  render() {
-    const { children } = this.props;
-    const { isEnabled, variables, canRender } = this.state;
-
-    if (!canRender) {
-      return null;
-    }
-
-    return children(isEnabled, variables);
-  }
-}
+  return children(isEnabled, variables);
+};
 
 export const OptimizelyFeature = withOptimizely(FeatureComponent);

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { useCallback, useContext, useEffect, useState } from 'react';
-import * as optimizely from '@optimizely/optimizely-sdk';
+import { UserAttributes } from '@optimizely/optimizely-sdk';
 import { getLogger } from '@optimizely/js-sdk-logging';
 
 import { setupAutoUpdateListeners } from './autoUpdate';
@@ -38,7 +38,7 @@ type UseFeatureOptions = {
 
 type UseFeatureOverrides = {
   overrideUserId?: string;
-  overrideAttributes?: optimizely.UserAttributes;
+  overrideAttributes?: UserAttributes;
 };
 
 interface UseFeature {


### PR DESCRIPTION
## Summary

Updates `<OptimizelyFeature>` to be a functional component that 

Also adds support for userId and userAttribute overrides.

Addresses #30 

### Release

Is this a breaking change? In theory the logic should behave the same, as #28 was designed to implement the same logic as `<OptimizelyFeature>`.

Timing wise, when `isServerSide` is false, the state setting of the correct values of the feature/variables in `useFeature` happens in a second chained _thennable_, rather than the first.

I dont think this should be considered a breaking change (and thus warrant a major release), but I wanted to point it out.