### PR TITLE
chore (Hooks): Move common client ready logic to a separate function

### DIFF
--- a/src/autoUpdate.ts
+++ b/src/autoUpdate.ts
@@ -21,7 +21,7 @@ import { ReactSDKClient } from './client';
 interface AutoUpdate {
   (
     optimizely: ReactSDKClient,
-    type: 'feature' | 'experiment',
+    type: 'Feature' | 'Experiment',
     value: string,
     logger: LoggerFacade,
     callback: () => void
@@ -41,7 +41,7 @@ export const setupAutoUpdateListeners: AutoUpdate = (optimizely, type, value, lo
       callback();
     }
   );
-  const unregisterConfigUpdateListener = () =>
+  const unregisterConfigUpdateListener: () => void = () =>
     optimizely.notificationCenter.removeNotificationListener(optimizelyNotificationId);
 
   const unregisterUserListener = optimizely.onUserUpdate(() => {
@@ -49,7 +49,7 @@ export const setupAutoUpdateListeners: AutoUpdate = (optimizely, type, value, lo
     callback();
   });
 
-  return () => {
+  return (): void => {
     unregisterConfigUpdateListener();
     unregisterUserListener();
   };

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -15,13 +15,18 @@
  */
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { UserAttributes } from '@optimizely/optimizely-sdk';
-import { getLogger } from '@optimizely/js-sdk-logging';
+import { getLogger, LoggerFacade } from '@optimizely/js-sdk-logging';
 
 import { setupAutoUpdateListeners } from './autoUpdate';
-import { VariableValuesObject, OnReadyResult } from './client';
+import { ReactSDKClient, VariableValuesObject, OnReadyResult } from './client';
 import { OptimizelyContext } from './Context';
 
 const useFeatureLogger = getLogger('useFeature');
+
+enum HookType {
+  EXPERIMENT = 'experiment',
+  FEATURE = 'feature',
+}
 
 type UseFeatureState = {
   isEnabled: boolean;
@@ -51,6 +56,68 @@ interface UseFeature {
 }
 
 /**
+ * A function which waits for the optimizely client instance passed to become
+ * ready and then sets up initial state and (optionally) autoUpdate listeners
+ * for the hook type specified.
+ */
+const initializeWhenClientReadyFn = (
+  type: HookType,
+  name: string,
+  optimizely: ReactSDKClient,
+  options: UseFeatureOptions,
+  logger: LoggerFacade,
+  timeout: number | undefined,
+  setDidTimeout: (val: boolean) => void,
+  setClientReady: (val: boolean) => void,
+  setData: (val: UseFeatureState) => void,
+  getCurrentValues: () => UseFeatureState
+): (() => void) => {
+  return (): (() => void) => {
+    const cleanupFns: Array<() => void> = [];
+    const finalReadyTimeout: number | undefined = options.timeout !== undefined ? options.timeout : timeout;
+
+    optimizely
+      .onReady({ timeout: finalReadyTimeout })
+      .then((res: OnReadyResult) => {
+        if (res.success) {
+          // didTimeout=false
+          logger.info(`${type}="${name}" successfully set for user="${optimizely.user.id}"`);
+          return;
+        }
+        setDidTimeout(true);
+        logger.info(`${type}="${name}" could not be set before timeout of ${timeout}ms, reason="${res.reason || ''}"`);
+        // Since we timed out, wait for the dataReadyPromise to resolve before setting up.
+        return res.dataReadyPromise!.then(() => {
+          logger.info(`${type}="${name}" is now set, but after timeout.`);
+        });
+      })
+      .then(() => {
+        setClientReady(true);
+        setData(getCurrentValues());
+        if (options.autoUpdate) {
+          cleanupFns.push(
+            setupAutoUpdateListeners(optimizely, type, name, logger, () => {
+              if (cleanupFns.length) {
+                setData(getCurrentValues());
+              }
+            })
+          );
+        }
+      })
+      .catch(() => {
+        /* The user promise or core client promise rejected. */
+        logger.error(`Error initializing client. The core client or user promise(s) rejected.`);
+      });
+
+    return (): void => {
+      while (cleanupFns.length) {
+        cleanupFns.shift()!();
+      }
+    };
+  };
+};
+
+/**
  * A React Hook that retrieves the status of a feature flag and its variables, optionally
  * auto updating those values based on underlying user or datafile changes.
  *
@@ -62,7 +129,6 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
   if (!optimizely) {
     throw new Error('optimizely prop must be supplied via a parent <OptimizelyProvider>');
   }
-  const finalReadyTimeout: number | undefined = options.timeout !== undefined ? options.timeout : timeout;
 
   // Helper function to return the current values for isEnabled and variables.
   const getCurrentValues = useCallback(
@@ -84,51 +150,21 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
   const [clientReady, setClientReady] = useState(isServerSide ? true : false);
   const [didTimeout, setDidTimeout] = useState(false);
 
-  useEffect(() => {
-    const cleanupFns: Array<() => void> = [];
-
-    optimizely
-      .onReady({ timeout: finalReadyTimeout })
-      .then((res: OnReadyResult) => {
-        if (res.success) {
-          // didTimeout=false
-          useFeatureLogger.info(`feature="${featureKey}" successfully set for user="${optimizely.user.id}"`);
-          return;
-        }
-        setDidTimeout(true);
-        useFeatureLogger.info(
-          `feature="${featureKey}" could not be set before timeout of ${finalReadyTimeout}ms, reason="${res.reason ||
-            ''}"`
-        );
-        // Since we timed out, wait for the dataReadyPromise to resolve before setting up.
-        return res.dataReadyPromise!.then(() => {
-          useFeatureLogger.info(`feature="${featureKey}" is now set, but after timeout.`);
-        });
-      })
-      .then(() => {
-        setClientReady(true);
-        setData(getCurrentValues());
-        if (options.autoUpdate) {
-          cleanupFns.push(
-            setupAutoUpdateListeners(optimizely, 'feature', featureKey, useFeatureLogger, () => {
-              if (cleanupFns.length) {
-                setData(getCurrentValues());
-              }
-            })
-          );
-        }
-      })
-      .catch(() => {
-        /* The user promise or core client promise rejected. */
-        useFeatureLogger.error(`Error initializing client. The core client or user promise(s) rejected.`);
-      });
-
-    return () => {
-      while (cleanupFns.length) {
-        cleanupFns.shift()!();
-      }
-    };
-  }, [optimizely]);
+  useEffect(
+    initializeWhenClientReadyFn(
+      HookType.FEATURE,
+      featureKey,
+      optimizely,
+      options,
+      useFeatureLogger,
+      timeout,
+      setDidTimeout,
+      setClientReady,
+      setData,
+      getCurrentValues
+    ),
+    [optimizely]
+  );
 
   return [data.isEnabled, data.variables, clientReady, didTimeout];
 };

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -101,7 +101,7 @@ const initializeWhenClientReadyFn = (
           logger.info(`${type}="${name}" successfully set for user="${optimizely.user.id}"`);
           return;
         }
-        setState((state: HookState) => Object.assign({}, state, { didTimeout: true }));
+        setState((state: HookState) => ({ ...state, didTimeout: true }));
         logger.info(`${type}="${name}" could not be set before timeout of ${timeout}ms, reason="${res.reason || ''}"`);
         // Since we timed out, wait for the dataReadyPromise to resolve before setting up.
         return res.dataReadyPromise!.then(() => {
@@ -109,12 +109,12 @@ const initializeWhenClientReadyFn = (
         });
       })
       .then(() => {
-        setState((state: HookState) => Object.assign({}, state, { clientReady: true }, getCurrentDecisionValues()));
+        setState((state: HookState) => ({ ...state, ...getCurrentDecisionValues(), clientReady: true }));
         if (options.autoUpdate) {
           cleanupFns.push(
             setupAutoUpdateListeners(optimizely, type, name, logger, () => {
               if (cleanupFns.length) {
-                setState((state: HookState) => Object.assign({}, state, getCurrentDecisionValues()));
+                setState((state: HookState) => ({ ...state, ...getCurrentDecisionValues() }));
               }
             })
           );
@@ -164,7 +164,7 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
       didTimeout: false,
     };
     if (isServerSide) {
-      return Object.assign(initialState, getCurrentValues());
+      return { ...initialState, ...getCurrentValues() };
     }
     return initialState;
   });


### PR DESCRIPTION
## Summary

In preparation to introduce a `useExperiment` hook, this PR moves the logic for waiting for the client to become ready, setting initial state, and configuring autoupdate to a shared function, which is passed to `useEffect`

There are a lot of variables that need to be passed, but I think this is much preferable to duplicating the somewhat intricate & nuanced logic that exists there.

## Test Plan

Existing unit tests cover this functionality, and more will be added with the introduction of `useExperiment`