### PR TITLE
chore (ESLint): Add no-shadow rule to error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,5 +26,6 @@ module.exports = {
     '@typescript-eslint/ban-ts-ignore': 'off',
     '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/no-empty-function': 'off',
+    'no-shadow': 'error',
   },
 };

--- a/src/Feature.spec.tsx
+++ b/src/Feature.spec.tsx
@@ -26,7 +26,7 @@ import { OptimizelyFeature } from './Feature';
 describe('<OptimizelyFeature>', () => {
   let resolver: any;
   let optimizelyMock: ReactSDKClient;
-  const isEnabled = true;
+  const isEnabledMock = true;
   const featureVariables = {
     foo: 'bar',
   };
@@ -42,7 +42,7 @@ describe('<OptimizelyFeature>', () => {
     optimizelyMock = ({
       onReady: jest.fn().mockImplementation(config => onReadyPromise),
       getFeatureVariables: jest.fn().mockImplementation(() => featureVariables),
-      isFeatureEnabled: jest.fn().mockImplementation(() => isEnabled),
+      isFeatureEnabled: jest.fn().mockImplementation(() => isEnabledMock),
       onUserUpdate: jest.fn().mockImplementation(handler => () => {}),
       notificationCenter: {
         addNotificationListener: jest.fn().mockImplementation((type, handler) => {}),

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as React from 'react';
-import * as optimizely from '@optimizely/optimizely-sdk';
+import { UserAttributes } from '@optimizely/optimizely-sdk';
 import { getLogger } from '@optimizely/js-sdk-logging';
 
 import { OptimizelyContextProvider } from './Context';
@@ -25,7 +25,7 @@ const logger = getLogger('<OptimizelyProvider>');
 
 type UserInfo = {
   id: string;
-  attributes?: optimizely.UserAttributes;
+  attributes?: UserAttributes;
 };
 
 interface OptimizelyProviderProps {
@@ -34,7 +34,7 @@ interface OptimizelyProviderProps {
   isServerSide?: boolean;
   user?: Promise<UserInfo> | UserInfo;
   userId?: string;
-  userAttributes?: optimizely.UserAttributes;
+  userAttributes?: UserAttributes;
 }
 
 interface OptimizelyProviderState {
@@ -50,13 +50,13 @@ export class OptimizelyProvider extends React.Component<OptimizelyProviderProps,
     // check if user id/attributes are provided as props and set them ReactSDKClient
     let finalUser: {
       id: string;
-      attributes: optimizely.UserAttributes;
+      attributes: UserAttributes;
     } | null = null;
 
     if (user) {
       if ('then' in user) {
-        user.then(user => {
-          optimizely.setUser(user);
+        user.then((res: UserInfo) => {
+          optimizely.setUser(res);
         });
       } else {
         finalUser = {


### PR DESCRIPTION
## Summary

This rule prevents shadowing variable names that are already declared in the upper scope.

It includes fixes for all the current violations of this.