### PR TITLE
Allow more acceptable versions of utility-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@optimizely/optimizely-sdk": "3.6.0-alpha.1",
     "hoist-non-react-statics": "^3.3.0",
     "prop-types": "^15.6.2",
-    "utility-types": "^2.1.0"
+    "utility-types": "^2.1.0 || ^3.0.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4931,10 +4931,10 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-utility-types@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-2.1.0.tgz#0c78fc9f7eb424d14302222b4ddd13fdb17f44ab"
-  integrity sha512-/nP2gqavggo6l38rtQI/CdeV+2fmBGXVvHgj9kV2MAnms3TIi77Mz9BtapPFI0+GZQCqqom0vACQ+VlTTaCovw==
+"utility-types@^2.1.0 || ^3.0.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.10.0.tgz#ea4148f9a741015f05ed74fd615e1d20e6bed82b"
+  integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==
 
 uuid@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
I'm trying to decrease my dependency install times and this would help de-duplicate my dependency tree. Seems this project only needs `Subtract` which is present in both 2.x and 3.x