### PR TITLE
fix: Export useExperiment hook from index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@
 export { OptimizelyContext, OptimizelyContextConsumer, OptimizelyContextProvider } from './Context';
 export { OptimizelyProvider } from './Provider';
 export { OptimizelyFeature } from './Feature';
-export { useFeature } from './hooks';
+export { useFeature, useExperiment } from './hooks';
 export { withOptimizely, WithOptimizelyProps, WithoutOptimizelyProps } from './withOptimizely';
 export { OptimizelyExperiment } from './Experiment';
 export { OptimizelyVariation } from './Variation';


### PR DESCRIPTION
Make `useExperiment` hook available as an export from the top level package module.