### PR TITLE
refactor(client): In getFeatureVariables, use OptimizelyConfig instead of internal ProjectConfig

### DIFF
--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -460,58 +460,69 @@ describe('ReactSDKClient', () => {
 
     describe('getFeatureVariables', () => {
       it('returns an empty object when the inner SDK returns no variables', () => {
-        const anyClient = mockInnerClient as any;
-        anyClient.getFeatureVariableBoolean.mockReturnValue(null);
-        anyClient.getFeatureVariableString.mockReturnValue(null);
-        anyClient.getFeatureVariableInteger.mockReturnValue(null);
-        anyClient.getFeatureVariableDouble.mockReturnValue(null);
-        anyClient.getFeatureVariableJSON.mockReturnValue(null);
+        (mockInnerClient.getFeatureVariable as jest.Mock).mockReturnValue(null);
         const instance = createInstance(config);
         const result = instance.getFeatureVariables('feat1');
         expect(result).toEqual({});
       });
 
       it('returns an object with variables of all types returned from the inner sdk ', () => {
-        const anyClient = mockInnerClient as any;
-        anyClient.projectConfigManager = {
-          getConfig() {
-            return {
-              featureKeyMap: {
-                feat1: {
-                  variables: [
-                    {
-                      type: 'boolean',
-                      key: 'bvar',
-                    },
-                    {
-                      type: 'string',
-                      key: 'svar',
-                    },
-                    {
-                      type: 'integer',
-                      key: 'ivar',
-                    },
-                    {
-                      type: 'double',
-                      key: 'dvar',
-                    },
-                    {
-                      type: 'json',
-                      key: 'jvar',
-                    },
-                  ],
+        (mockInnerClient.getOptimizelyConfig as jest.Mock).mockReturnValue({
+          featuresMap: {
+            feat1: {
+              variablesMap: {
+                bvar: {
+                  id: '0',
+                  key: 'bvar',
+                  type: 'boolean',
+                  value: 'false',
+                },
+                svar: {
+                  id: '1',
+                  key: 'svar',
+                  type: 'string',
+                  value: '',
+                },
+                ivar: {
+                  id: '2',
+                  key: 'ivar',
+                  type: 'integer',
+                  value: '0',
+                },
+                dvar: {
+                  id: '3',
+                  key: 'dvar',
+                  type: 'double',
+                  value: '0',
+                },
+                jvar: {
+                  id: '4',
+                  key: 'jvar',
+                  type: 'json',
+                  value: '{}',
                 },
               },
-            };
+            },
           },
-        };
-        anyClient.getFeatureVariableBoolean.mockReturnValue(true);
-        anyClient.getFeatureVariableString.mockReturnValue('whatsup');
-        anyClient.getFeatureVariableInteger.mockReturnValue(10);
-        anyClient.getFeatureVariableDouble.mockReturnValue(-10.5);
-        anyClient.getFeatureVariableJSON.mockReturnValue({
-          value: 'json value',
         });
+        (mockInnerClient.getFeatureVariable as jest.Mock).mockImplementation(
+          (featureKey: string, variableKey: string) => {
+            switch (variableKey) {
+              case 'bvar':
+                return true;
+              case 'svar':
+                return 'whatsup';
+              case 'ivar':
+                return 10;
+              case 'dvar':
+                return -10.5;
+              case 'jvar':
+                return { value: 'json value' };
+              default:
+                return null;
+            }
+          }
+        );
         const instance = createInstance(config);
         instance.setUser({
           id: 'user1123',

--- a/src/client.ts
+++ b/src/client.ts
@@ -360,40 +360,17 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     }
     const userAttributes = user.attributes;
     const variableObj: { [key: string]: any } = {};
-    const config = (this._client as any).projectConfigManager.getConfig();
-    if (!config) {
+    const optlyConfig = this._client.getOptimizelyConfig();
+    if (!optlyConfig) {
       return {};
     }
-    const feature = config.featureKeyMap[featureKey];
+    const feature = optlyConfig.featuresMap[featureKey];
     if (!feature) {
       return {};
     }
-    const variables: object[] = feature.variables;
-    variables.forEach((variableDef: any) => {
-      const type: any = variableDef.type;
-      const key: any = variableDef.key;
-
-      switch (type) {
-        case 'string':
-          variableObj[key] = this._client.getFeatureVariableString(featureKey, key, userId, userAttributes);
-          break;
-
-        case 'boolean':
-          variableObj[key] = this._client.getFeatureVariableBoolean(featureKey, key, userId, userAttributes);
-          break;
-
-        case 'integer':
-          variableObj[key] = this._client.getFeatureVariableInteger(featureKey, key, userId, userAttributes);
-          break;
-
-        case 'double':
-          variableObj[key] = this._client.getFeatureVariableDouble(featureKey, key, userId, userAttributes);
-          break;
-
-        case 'json':
-          variableObj[key] = this._client.getFeatureVariableJSON(featureKey, key, userId, userAttributes);
-          break;
-      }
+    Object.keys(feature.variablesMap).forEach(key => {
+      const variable = feature.variablesMap[key];
+      variableObj[variable.key] = this._client.getFeatureVariable(featureKey, variable.key, userId, userAttributes);
     });
 
     return variableObj;


### PR DESCRIPTION
## Summary

`getFeatureVariables` reaches inside the optimizely-sdk client to access its project config manager, to find what variables are associated with a given feature key. In recent versions of optimizely-sdk, it is no longer necessary to access project config manager to get this information. Features and variables are available via the public, documented `OptimizelyConfig` interface. This PR updates `getFeatureVariables` to use `OptimizelyConfig`.

## Test Plan

- Updated unit tests
- Manual testing