### PR TITLE
chore: Prepare for 2.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.3.2] - October 7th, 2020
+Upgrade `@optimizely/optimizely-sdk` to [4.3.3](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.3). Exported Optimizely Config Entities types from TypeScript type definitions. See [@optimizely/optimizely-sdk Release 4.3.3](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.3) for more details.
+
 ## [2.3.1] - October 5th, 2020
 Upgrade `@optimizely/optimizely-sdk` to [4.3.1](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.1). Added support for version audience evaluation and datafile accessor. See [@optimizely/optimizely-sdk Release 4.3.0](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.0) for more details.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.3.2] - October 8th, 2020
-Upgrade `@optimizely/optimizely-sdk` to [4.3.3](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.3):
+## [2.3.2] - October 9th, 2020
+Upgrade `@optimizely/optimizely-sdk` to [4.3.4](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.4):
   - Exported Optimizely Config Entities types from TypeScript type definitions. See [@optimizely/optimizely-sdk Release 4.3.3](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.3) for more details.
   - Fixed return type of `getAllFeatureVariables` method in TypeScript type definitions. See [@optimizely/optimizely-sdk Release 4.3.2](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.2) for more details.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Upgrade `@optimizely/optimizely-sdk` to [4.3.3](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.3):
   - Exported Optimizely Config Entities types from TypeScript type definitions. See [@optimizely/optimizely-sdk Release 4.3.3](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.3) for more details.
   - Fixed return type of `getAllFeatureVariables` method in TypeScript type definitions. See [@optimizely/optimizely-sdk Release 4.3.2](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.2) for more details.
+
 ### Bug fixes
   - Fixed return type of `getAllFeatureVariables` method in ReactSDKClient ([#76](https://github.com/optimizely/react-sdk/pull/76))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.3.2] - October 7th, 2020
+## [2.3.2] - October 8th, 2020
 Upgrade `@optimizely/optimizely-sdk` to [4.3.3](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.3):
   - Exported Optimizely Config Entities types from TypeScript type definitions. See [@optimizely/optimizely-sdk Release 4.3.3](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.3) for more details.
   - Fixed return type of `getAllFeatureVariables` method in TypeScript type definitions. See [@optimizely/optimizely-sdk Release 4.3.2](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.2) for more details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [2.3.2] - October 7th, 2020
-Upgrade `@optimizely/optimizely-sdk` to [4.3.3](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.3). Exported Optimizely Config Entities types from TypeScript type definitions. See [@optimizely/optimizely-sdk Release 4.3.3](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.3) for more details.
+Upgrade `@optimizely/optimizely-sdk` to [4.3.3](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.3):
+  - Exported Optimizely Config Entities types from TypeScript type definitions. See [@optimizely/optimizely-sdk Release 4.3.3](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.3) for more details.
+  - Fixed return type of `getAllFeatureVariables` method in TypeScript type definitions. See [@optimizely/optimizely-sdk Release 4.3.2](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.2) for more details.
+### Bug fixes
+  - Fixed return type of `getAllFeatureVariables` method in ReactSDKClient ([#76](https://github.com/optimizely/react-sdk/pull/76))
 
 ## [2.3.1] - October 5th, 2020
 Upgrade `@optimizely/optimizely-sdk` to [4.3.1](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.1). Added support for version audience evaluation and datafile accessor. See [@optimizely/optimizely-sdk Release 4.3.0](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.0) for more details.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@optimizely/js-sdk-logging": "^0.1.0",
-    "@optimizely/optimizely-sdk": "^4.3.3",
+    "@optimizely/optimizely-sdk": "^4.3.4",
     "hoist-non-react-statics": "^3.3.0",
     "prop-types": "^15.6.2",
     "utility-types": "^2.1.0 || ^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/react-sdk",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "React SDK for Optimizely Full Stack and Optimizely Rollouts",
   "homepage": "https://github.com/optimizely/react-sdk",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@optimizely/js-sdk-logging": "^0.1.0",
-    "@optimizely/optimizely-sdk": "4.3.3",
+    "@optimizely/optimizely-sdk": "^4.3.3",
     "hoist-non-react-statics": "^3.3.0",
     "prop-types": "^15.6.2",
     "utility-types": "^2.1.0 || ^3.0.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@optimizely/js-sdk-logging": "^0.1.0",
-    "@optimizely/optimizely-sdk": "4.3.1",
+    "@optimizely/optimizely-sdk": "4.3.3",
     "hoist-non-react-statics": "^3.3.0",
     "prop-types": "^15.6.2",
     "utility-types": "^2.1.0 || ^3.0.0"

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -91,7 +91,7 @@ describe('ReactSDKClient', () => {
     expect(createInstanceSpy).toBeCalledWith({
       ...config,
       clientEngine: 'react-sdk',
-      clientVersion: '2.3.1',
+      clientVersion: '2.3.2',
     });
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -109,7 +109,7 @@ export interface ReactSDKClient extends optimizely.Client {
     featureKey: string,
     overrideUserId: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): { [variableKey: string]: unknown };
+  ): { [variableKey: string]: unknown } | null;
 
   isFeatureEnabled(
     featureKey: string,
@@ -526,7 +526,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     featureKey: string,
     overrideUserId: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): { [variableKey: string]: unknown } {
+  ): { [variableKey: string]: unknown } | null {
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
     if (user.id === null) {
       return {};

--- a/src/client.ts
+++ b/src/client.ts
@@ -35,7 +35,7 @@ export type OnReadyResult = {
 };
 
 const REACT_SDK_CLIENT_ENGINE = 'react-sdk';
-const REACT_SDK_CLIENT_VERSION = '2.3.1';
+const REACT_SDK_CLIENT_VERSION = '2.3.2';
 
 export interface ReactSDKClient extends optimizely.Client {
   user: UserContext;

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,10 +64,10 @@
   dependencies:
     uuid "^3.3.2"
 
-"@optimizely/optimizely-sdk@4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-4.3.1.tgz#667666bb55a5c9909764d3ebaafecbca66c8c6f6"
-  integrity sha512-22wglT1USthyVRn+TocFCQ4x0Z9sgQTe9dKhebE+tF6CJu/ocHexQY8cKMbPr4qvO270Y4zbNEYjdg3MvMeeDQ==
+"@optimizely/optimizely-sdk@4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-4.3.3.tgz#91db4072f8e439d997370ad48c25106610f2e4a3"
+  integrity sha512-tz6GyJMM4TUpLTsoyO9ZKNB5/UswtKSF4jLlBG1N6hWVi+bCJUa25M4Ok6DA0izZ2k0Y2xmUQDVmV4p23Li5Gw==
   dependencies:
     "@optimizely/js-sdk-datafile-manager" "^0.8.0"
     "@optimizely/js-sdk-event-processor" "^0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,10 +64,10 @@
   dependencies:
     uuid "^3.3.2"
 
-"@optimizely/optimizely-sdk@^4.3.3":
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-4.3.3.tgz#91db4072f8e439d997370ad48c25106610f2e4a3"
-  integrity sha512-tz6GyJMM4TUpLTsoyO9ZKNB5/UswtKSF4jLlBG1N6hWVi+bCJUa25M4Ok6DA0izZ2k0Y2xmUQDVmV4p23Li5Gw==
+"@optimizely/optimizely-sdk@^4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-4.3.4.tgz#b323b91dc8af9656dde8bcf696801bd71443e202"
+  integrity sha512-DqaEg9YwiwnfDjaDmbST2cu0/7W/yQJqQ+tBwIEwh/HqiSgs8oQJX7sNG2Ql2fFwlIzG7APkIx/oxwbXpp8LPg==
   dependencies:
     "@optimizely/js-sdk-datafile-manager" "^0.8.0"
     "@optimizely/js-sdk-event-processor" "^0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,7 +64,7 @@
   dependencies:
     uuid "^3.3.2"
 
-"@optimizely/optimizely-sdk@4.3.3":
+"@optimizely/optimizely-sdk@^4.3.3":
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-4.3.3.tgz#91db4072f8e439d997370ad48c25106610f2e4a3"
   integrity sha512-tz6GyJMM4TUpLTsoyO9ZKNB5/UswtKSF4jLlBG1N6hWVi+bCJUa25M4Ok6DA0izZ2k0Y2xmUQDVmV4p23Li5Gw==


### PR DESCRIPTION
## Summary:

- Upgrade `@optimizely/optimizely-sdk` to compatible-version dependency [4.3.4](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.4)
- Fixed return type of `getAllFeatureVariables` method in ReactSDKClient


## Test:

Existing unit tests