### PR TITLE
fix: logOnlyEventDispatcher matches expected type and calls done callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Bug fixes
+- Fix `logOnlyEventDispatcher` to conform to `EventDispatcher` type from @optimizely/optimizely-sdk ([#81](https://github.com/optimizely/react-sdk/pull/81))
+
 ## [2.3.2] - October 9th, 2020
 Upgrade `@optimizely/optimizely-sdk` to [4.3.4](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.4):
   - Exported Optimizely Config Entities types from TypeScript type definitions. See [@optimizely/optimizely-sdk Release 4.3.3](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.3) for more details.

--- a/src/logOnlyEventDispatcher.spec.ts
+++ b/src/logOnlyEventDispatcher.spec.ts
@@ -1,0 +1,17 @@
+jest.mock('@optimizely/js-sdk-logging', () => ({
+  getLogger: jest.fn().mockReturnValue({ debug: jest.fn() }),
+}));
+
+import logOnlyEventDispatcher from './logOnlyEventDispatcher';
+import * as logging from '@optimizely/js-sdk-logging';
+
+const logger = logging.getLogger('ReactSDK');
+
+describe('logOnlyEventDispatcher', () => {
+  it('logs a message', () => {
+    const callback = jest.fn();
+    logOnlyEventDispatcher.dispatchEvent({ url: 'https://localhost:8080', httpVerb: 'POST', params: {} }, callback);
+    expect(callback).toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalled();
+  });
+});

--- a/src/logOnlyEventDispatcher.ts
+++ b/src/logOnlyEventDispatcher.ts
@@ -35,7 +35,7 @@ const logOnlyEventDispatcher: optimizely.EventDispatcher = {
       }
       return eventStr;
     });
-    callback({ statusCode: 200 });
+    callback({ statusCode: 204 });
   },
 };
 

--- a/src/logOnlyEventDispatcher.ts
+++ b/src/logOnlyEventDispatcher.ts
@@ -25,7 +25,7 @@ const logger = logging.getLogger('ReactSDK');
  * all event dispatching.
  */
 const logOnlyEventDispatcher: optimizely.EventDispatcher = {
-  dispatchEvent(event: optimizely.Event, callback: () => void): void {
+  dispatchEvent(event: optimizely.Event, callback: (response: { statusCode: number }) => void): void {
     logger.debug('Event not dispatched by disabled event dispatcher: %s', () => {
       let eventStr: string;
       try {
@@ -35,6 +35,7 @@ const logOnlyEventDispatcher: optimizely.EventDispatcher = {
       }
       return eventStr;
     });
+    callback({ statusCode: 200 });
   },
 };
 


### PR DESCRIPTION
## Summary

- Update `logOnlyEventDispatcher` to be compatible with new type definition for `EventDispatcher`, introduced in optimizely-sdk 4.3.4
- Make `logOnlyEventDispatcher` call the done callback

## Test Plan
Added unit test