### PR TITLE
build: Change file extension for ES module bundle from .mjs to .es.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug fixes
 - Fix `logOnlyEventDispatcher` to conform to `EventDispatcher` type from @optimizely/optimizely-sdk ([#81](https://github.com/optimizely/react-sdk/pull/81))
+- Change the file extension of the ES module bundle from .mjs to .es.js. Resolves issues using React SDK with Gatsby.
 
 ## [2.3.2] - October 9th, 2020
 Upgrade `@optimizely/optimizely-sdk` to [4.3.4](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.4):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug fixes
 - Fix `logOnlyEventDispatcher` to conform to `EventDispatcher` type from @optimizely/optimizely-sdk ([#81](https://github.com/optimizely/react-sdk/pull/81))
-- Change the file extension of the ES module bundle from .mjs to .es.js. Resolves issues using React SDK with Gatsby.
+- Change the file extension of the ES module bundle from .mjs to .es.js. Resolves issues using React SDK with Gatsby ([#82](https://github.com/optimizely/react-sdk/pull/82)).
 
 ## [2.3.2] - October 9th, 2020
 Upgrade `@optimizely/optimizely-sdk` to [4.3.4](https://github.com/optimizely/javascript-sdk/releases/tag/v4.3.4):

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React SDK for Optimizely Full Stack and Optimizely Rollouts",
   "homepage": "https://github.com/optimizely/react-sdk",
   "license": "Apache-2.0",
-  "module": "dist/react-sdk.mjs",
+  "module": "dist/react-sdk.es.js",
   "types": "dist/index.d.ts",
   "main": "dist/react-sdk.js",
   "browser": "dist/react-sdk.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -32,7 +32,7 @@ const umdName = 'optimizelyReactSdk'
 
 console.log("\nBuilding ES modules...");
 
-exec(`./node_modules/.bin/rollup -c scripts/config.js -f es -o dist/${packageName}.mjs`);
+exec(`./node_modules/.bin/rollup -c scripts/config.js -f es -o dist/${packageName}.es.js`);
 
 console.log("\nBuilding CommonJS modules...");
 


### PR DESCRIPTION
## Summary

Using the .mjs file extension causes issues using React SDK with Gatsby's Node.js build process. Changing the extension to .es.js appears to resolve those issues.

## Test Plan

Created a test Gatsby application, ran `gatsby build`. It completed with no errors.