### PR TITLE
fix(hooks): Always recompute decision after resolution of ready promise

### DIFF
--- a/src/Experiment.spec.tsx
+++ b/src/Experiment.spec.tsx
@@ -76,7 +76,6 @@ describe('<OptimizelyExperiment>', () => {
 
       // Simulate client becoming ready: onReady resolving, firing config update notification
       resolver.resolve({ success: true });
-      (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
 
       await optimizelyMock.onReady();
 
@@ -101,7 +100,6 @@ describe('<OptimizelyExperiment>', () => {
 
       // Simulate client becoming ready: onReady resolving, firing config update notification
       resolver.resolve({ success: true });
-      (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
 
       await optimizelyMock.onReady();
 
@@ -121,9 +119,8 @@ describe('<OptimizelyExperiment>', () => {
       // while it's waiting for onReady()
       expect(component.text()).toBe('');
 
-      // Simulate client becoming ready: onReady resolving, firing config update notification
+      // Simulate client becoming ready,
       resolver.resolve({ success: true });
-      (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
 
       await optimizelyMock.onReady();
 
@@ -144,9 +141,8 @@ describe('<OptimizelyExperiment>', () => {
       // while it's waiting for onReady()
       expect(component.text()).toBe('');
 
-      // Simulate client becoming ready: onReady resolving, firing config update notification
+      // Simulate client becoming ready
       resolver.resolve({ success: true });
-      (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
 
       await optimizelyMock.onReady();
 
@@ -212,9 +208,8 @@ describe('<OptimizelyExperiment>', () => {
       // while it's waiting for onReady()
       expect(component.text()).toBe('');
 
-      // Simulate client becoming ready: onReady resolving, firing config update notification
+      // Simulate client becoming ready
       resolver.resolve({ success: true });
-      (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
 
       await optimizelyMock.onReady();
 
@@ -237,9 +232,8 @@ describe('<OptimizelyExperiment>', () => {
       // while it's waiting for onReady()
       expect(component.text()).toBe('');
 
-      // Simulate client becoming ready: onReady resolving, firing config update notification
+      // Simulate client becoming ready
       resolver.resolve({ success: true });
-      (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
 
       await optimizelyMock.onReady();
 
@@ -285,9 +279,8 @@ describe('<OptimizelyExperiment>', () => {
       // while it's waiting for onReady()
       expect(component.text()).toBe('');
 
-      // Simulate client becoming ready: onReady resolving, firing config update notification
+      // Simulate client becoming ready
       resolver.resolve({ success: true });
-      (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
 
       await optimizelyMock.onReady();
 
@@ -298,11 +291,11 @@ describe('<OptimizelyExperiment>', () => {
       expect(component.text()).toBe('variationResult');
 
       // capture the OPTIMIZELY_CONFIG_UPDATE function
-      const updateFn = (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1];
       // change the return value of activate
       const mockActivate = optimizelyMock.activate as jest.Mock;
       mockActivate.mockImplementationOnce(() => 'newVariation');
 
+      const updateFn = (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1];
       updateFn();
       expect(optimizelyMock.activate).toBeCalledTimes(2);
 
@@ -324,10 +317,9 @@ describe('<OptimizelyExperiment>', () => {
       expect(optimizelyMock.onReady).toHaveBeenCalledWith({ timeout: 100 });
       // while it's waiting for onReady()
       expect(component.text()).toBe('');
-      resolver.resolve({ success: true });
 
-      // Simulate config update update notification firing after datafile becomes available.
-      (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
+      // Simulate client becoming ready
+      resolver.resolve({ success: true });
 
       await optimizelyMock.onReady();
 

--- a/src/Experiment.spec.tsx
+++ b/src/Experiment.spec.tsx
@@ -119,7 +119,7 @@ describe('<OptimizelyExperiment>', () => {
       // while it's waiting for onReady()
       expect(component.text()).toBe('');
 
-      // Simulate client becoming ready,
+      // Simulate client becoming ready
       resolver.resolve({ success: true });
 
       await optimizelyMock.onReady();

--- a/src/Feature.spec.tsx
+++ b/src/Feature.spec.tsx
@@ -79,7 +79,7 @@ describe('<OptimizelyFeature>', () => {
 
       // Simulate client becoming ready
       resolver.resolve({ success: true });
-      (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
+      // (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
 
       await optimizelyMock.onReady();
 
@@ -106,7 +106,6 @@ describe('<OptimizelyFeature>', () => {
 
       // Simulate client becoming ready
       resolver.resolve({ success: true });
-      (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
 
       await optimizelyMock.onReady();
 
@@ -133,7 +132,6 @@ describe('<OptimizelyFeature>', () => {
 
       // Simulate client becoming ready
       resolver.resolve({ success: true });
-      (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
 
       await optimizelyMock.onReady();
 
@@ -160,7 +158,6 @@ describe('<OptimizelyFeature>', () => {
 
       // Simulate client becoming ready
       resolver.resolve({ success: true });
-      (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
 
       await optimizelyMock.onReady();
 
@@ -185,7 +182,6 @@ describe('<OptimizelyFeature>', () => {
 
       // Simulate client becoming ready
       resolver.resolve({ success: true });
-      (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
 
       await optimizelyMock.onReady();
 
@@ -212,9 +208,7 @@ describe('<OptimizelyFeature>', () => {
         expect(component.text()).toBe('');
 
         // Simulate client becoming ready
-        const updateFn = (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1];
         resolver.resolve({ success: true });
-        updateFn();
 
         await optimizelyMock.onReady();
 
@@ -232,6 +226,7 @@ describe('<OptimizelyFeature>', () => {
           foo: 'baz',
         }));
 
+        const updateFn = (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1];
         updateFn();
 
         component.update();
@@ -257,7 +252,6 @@ describe('<OptimizelyFeature>', () => {
         expect(component.text()).toBe('');
 
         // Simulate client becoming ready
-        (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
         resolver.resolve({ success: true });
 
         await optimizelyMock.onReady();
@@ -304,7 +298,6 @@ describe('<OptimizelyFeature>', () => {
         resolver.resolve({ success: false, reason: 'fail', dataReadyPromise: Promise.resolve() });
 
         // Simulate config update notification firing after datafile fetched
-        (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
         await optimizelyMock.onReady().then(res => res.dataReadyPromise);
 
         component.update();

--- a/src/Feature.spec.tsx
+++ b/src/Feature.spec.tsx
@@ -79,7 +79,6 @@ describe('<OptimizelyFeature>', () => {
 
       // Simulate client becoming ready
       resolver.resolve({ success: true });
-      // (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1]();
 
       await optimizelyMock.onReady();
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -99,64 +99,47 @@ function areDecisionInputsEqual(oldDecisionInputs: DecisionInputs, newDecisionIn
 }
 
 /**
- * Hook providing access to initialization state for the argument client (readiness, and whether or not a timeout occurred
- * based on the timeout passed in or set on the ancestor OptimizelyProvider)
+ * Subscribe to changes in initialization state of the argument client. onInitStateChange callback
+ * is called on the following events:
+ * - optimizely successfully becomes ready
+ * - timeout is reached prior to optimizely becoming ready
+ * - optimizely becomes ready after the timeout has already passed
  * @param {ReactSDKClient} optimizely
- * @param {HookOptions} [options]
- * @returns InitializationState
+ * @param {number|undefined} timeout
+ * @param {Function} onInitStateChange
  */
-function useClientInitializationState(optimizely: ReactSDKClient, options: HookOptions = {}): InitializationState {
-  const { timeout, isServerSide } = useContext(OptimizelyContext);
-  const isClientReady = optimizely.isReady() || isServerSide;
-
-  const [initializationState, setInitializationState] = useState<InitializationState>(() => ({
-    clientReady: isClientReady,
-    didTimeout: false,
-  }));
-
-  // Update initialization state when any of these occur:
-  // - Client instance changed
-  // - Timeout (obtained from provider or passed in) changed
-  // - onReady promise signaled timeout elapsed
-  // - client became ready
-  const finalReadyTimeout: number | undefined = options.timeout !== undefined ? options.timeout : timeout;
-  useEffect(() => {
-    if (isClientReady) {
-      return;
-    }
-
-    optimizely
-      .onReady({ timeout: finalReadyTimeout })
-      .then((res: OnReadyResult) => {
-        if (res.success) {
-          hooksLogger.info('Client became ready');
-          setInitializationState({
-            clientReady: true,
-            didTimeout: false,
-          });
-          return;
-        }
-        hooksLogger.info(
-          `Client did not become ready before timeout of ${finalReadyTimeout}ms, reason="${res.reason || ''}"`
-        );
-        setInitializationState({
-          clientReady: false,
+function subscribeToInitialization(
+  optimizely: ReactSDKClient,
+  timeout: number | undefined,
+  onInitStateChange: (initState: InitializationState) => void
+): void {
+  optimizely
+    .onReady({ timeout })
+    .then((res: OnReadyResult) => {
+      if (res.success) {
+        hooksLogger.info('Client became ready');
+        onInitStateChange({
+          clientReady: true,
+          didTimeout: false,
+        });
+        return;
+      }
+      hooksLogger.info(`Client did not become ready before timeout of ${timeout}ms, reason="${res.reason || ''}"`);
+      onInitStateChange({
+        clientReady: false,
+        didTimeout: true,
+      });
+      res.dataReadyPromise!.then(() => {
+        hooksLogger.info('Client became ready after timeout already elapsed');
+        onInitStateChange({
+          clientReady: true,
           didTimeout: true,
         });
-        res.dataReadyPromise!.then(() => {
-          hooksLogger.info('Client became ready after timeout already elapsed');
-          setInitializationState({
-            clientReady: true,
-            didTimeout: true,
-          });
-        });
-      })
-      .catch(() => {
-        hooksLogger.error(`Error initializing client. The core client or user promise(s) rejected.`);
       });
-  }, [isClientReady, optimizely, finalReadyTimeout]);
-
-  return initializationState;
+    })
+    .catch(() => {
+      hooksLogger.error(`Error initializing client. The core client or user promise(s) rejected.`);
+    });
 }
 
 function useCompareAttrsMemoize(value: UserAttributes | undefined): UserAttributes | undefined {
@@ -175,7 +158,7 @@ function useCompareAttrsMemoize(value: UserAttributes | undefined): UserAttribut
  *       ClientReady and DidTimeout provide signals to handle this scenario.
  */
 export const useExperiment: UseExperiment = (experimentKey, options = {}, overrides = {}) => {
-  const { optimizely, isServerSide } = useContext(OptimizelyContext);
+  const { optimizely, isServerSide, timeout } = useContext(OptimizelyContext);
   if (!optimizely) {
     throw new Error('optimizely prop must be supplied via a parent <OptimizelyProvider>');
   }
@@ -189,11 +172,13 @@ export const useExperiment: UseExperiment = (experimentKey, options = {}, overri
   );
 
   const isClientReady = isServerSide || optimizely.isReady();
-  const [decisionState, setDecisionState] = useState<ExperimentDecisionValues>(() => {
-    if (isClientReady) {
-      return getCurrentDecision();
-    }
-    return { variation: null };
+  const [state, setState] = useState<ExperimentDecisionValues & InitializationState>(() => {
+    const decisionState = isClientReady ? getCurrentDecision() : { variation: null };
+    return {
+      ...decisionState,
+      clientReady: isClientReady,
+      didTimeout: false,
+    };
   });
   // Decision state is derived from entityKey and overrides arguments.
   // Track the previous value of those arguments, and update state when they change.
@@ -207,21 +192,37 @@ export const useExperiment: UseExperiment = (experimentKey, options = {}, overri
   const [prevDecisionInputs, setPrevDecisionInputs] = useState<DecisionInputs>(currentDecisionInputs);
   if (!areDecisionInputsEqual(prevDecisionInputs, currentDecisionInputs)) {
     setPrevDecisionInputs(currentDecisionInputs);
-    setDecisionState(getCurrentDecision());
+    setState(prevState => ({
+      ...prevState,
+      ...getCurrentDecision(),
+    }));
   }
 
+  const finalReadyTimeout = options.timeout !== undefined ? options.timeout : timeout;
   useEffect(() => {
-    if (!isClientReady || options.autoUpdate) {
+    if (!isClientReady) {
+      subscribeToInitialization(optimizely, finalReadyTimeout, initState => {
+        setState({
+          ...getCurrentDecision(),
+          ...initState,
+        });
+      });
+    }
+  }, [isClientReady, finalReadyTimeout, setState, getCurrentDecision, optimizely]);
+
+  useEffect(() => {
+    if (options.autoUpdate) {
       return setupAutoUpdateListeners(optimizely, HookType.EXPERIMENT, experimentKey, hooksLogger, () => {
-        setDecisionState(getCurrentDecision());
+        setState(prevState => ({
+          ...prevState,
+          ...getCurrentDecision(),
+        }));
       });
     }
     return (): void => {};
-  }, [isClientReady, options.autoUpdate, optimizely, experimentKey, setDecisionState, getCurrentDecision]);
+  }, [isClientReady, options.autoUpdate, optimizely, experimentKey, setState, getCurrentDecision]);
 
-  const initializationState = useClientInitializationState(optimizely, options);
-
-  return [decisionState.variation, initializationState.clientReady, initializationState.didTimeout];
+  return [state.variation, state.clientReady, state.didTimeout];
 };
 
 /**
@@ -232,7 +233,7 @@ export const useExperiment: UseExperiment = (experimentKey, options = {}, overri
  *       ClientReady and DidTimeout provide signals to handle this scenario.
  */
 export const useFeature: UseFeature = (featureKey, options = {}, overrides = {}) => {
-  const { optimizely, isServerSide } = useContext(OptimizelyContext);
+  const { optimizely, isServerSide, timeout } = useContext(OptimizelyContext);
   if (!optimizely) {
     throw new Error('optimizely prop must be supplied via a parent <OptimizelyProvider>');
   }
@@ -247,11 +248,13 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
   );
 
   const isClientReady = isServerSide || optimizely.isReady();
-  const [decisionState, setDecisionState] = useState<FeatureDecisionValues>(() => {
-    if (isClientReady) {
-      return getCurrentDecision();
-    }
-    return { isEnabled: false, variables: {} };
+  const [state, setState] = useState<FeatureDecisionValues & InitializationState>(() => {
+    const decisionState = isClientReady ? getCurrentDecision() : { isEnabled: false, variables: {} };
+    return {
+      ...decisionState,
+      clientReady: isClientReady,
+      didTimeout: false,
+    };
   });
   // Decision state is derived from entityKey and overrides arguments.
   // Track the previous value of those arguments, and update state when they change.
@@ -265,24 +268,35 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
   const [prevDecisionInputs, setPrevDecisionInputs] = useState<DecisionInputs>(currentDecisionInputs);
   if (!areDecisionInputsEqual(prevDecisionInputs, currentDecisionInputs)) {
     setPrevDecisionInputs(currentDecisionInputs);
-    setDecisionState(getCurrentDecision());
+    setState(prevState => ({
+      ...prevState,
+      ...getCurrentDecision(),
+    }));
   }
 
+  const finalReadyTimeout = options.timeout !== undefined ? options.timeout : timeout;
   useEffect(() => {
-    if (!isClientReady || options.autoUpdate) {
+    if (!isClientReady) {
+      subscribeToInitialization(optimizely, finalReadyTimeout, initState => {
+        setState({
+          ...getCurrentDecision(),
+          ...initState,
+        });
+      });
+    }
+  }, [isClientReady, finalReadyTimeout, setState, getCurrentDecision, optimizely]);
+
+  useEffect(() => {
+    if (options.autoUpdate) {
       return setupAutoUpdateListeners(optimizely, HookType.FEATURE, featureKey, hooksLogger, () => {
-        setDecisionState(getCurrentDecision());
+        setState(prevState => ({
+          ...prevState,
+          ...getCurrentDecision(),
+        }));
       });
     }
     return (): void => {};
-  }, [isClientReady, options.autoUpdate, optimizely, featureKey, setDecisionState, getCurrentDecision]);
+  }, [isClientReady, options.autoUpdate, optimizely, featureKey, setState, getCurrentDecision]);
 
-  const initializationState = useClientInitializationState(optimizely, options);
-
-  return [
-    decisionState.isEnabled,
-    decisionState.variables,
-    initializationState.clientReady,
-    initializationState.didTimeout,
-  ];
+  return [state.isEnabled, state.variables, state.clientReady, state.didTimeout];
 };

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -208,7 +208,7 @@ export const useExperiment: UseExperiment = (experimentKey, options = {}, overri
         });
       });
     }
-  }, [isClientReady, finalReadyTimeout, setState, getCurrentDecision, optimizely]);
+  }, [isClientReady, finalReadyTimeout, getCurrentDecision, optimizely]);
 
   useEffect(() => {
     if (options.autoUpdate) {
@@ -220,7 +220,7 @@ export const useExperiment: UseExperiment = (experimentKey, options = {}, overri
       });
     }
     return (): void => {};
-  }, [isClientReady, options.autoUpdate, optimizely, experimentKey, setState, getCurrentDecision]);
+  }, [isClientReady, options.autoUpdate, optimizely, experimentKey, getCurrentDecision]);
 
   return [state.variation, state.clientReady, state.didTimeout];
 };
@@ -284,7 +284,7 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
         });
       });
     }
-  }, [isClientReady, finalReadyTimeout, setState, getCurrentDecision, optimizely]);
+  }, [isClientReady, finalReadyTimeout, getCurrentDecision, optimizely]);
 
   useEffect(() => {
     if (options.autoUpdate) {
@@ -296,7 +296,7 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
       });
     }
     return (): void => {};
-  }, [isClientReady, options.autoUpdate, optimizely, featureKey, setState, getCurrentDecision]);
+  }, [isClientReady, options.autoUpdate, optimizely, featureKey, getCurrentDecision]);
 
   return [state.isEnabled, state.variables, state.clientReady, state.didTimeout];
 };


### PR DESCRIPTION
## Summary

Fix the following bug: when client is initialized with datafile, and no SDK key, OptimizelyExperiment and OptimizelyFeature components don't properly render their decisions.

The issue is in the implementation in hooks and the interaction with the client's ready state (via `isReady`/`onReady`).  When initialized with datafile, the client begins in a non-ready state, but immediately becomes ready on the next tick. But the hook does not recompute the decision when this occurs - it's only recomputing the decision when a `CONFIG_UPDATE` is fired. `CONFIG_UPDATE` is never fired when the instance was initialized with datafile only.

To fix, add an effect in the `useFeature`/`useExperiment` hooks that recomputes the decision after the client becomes ready.

## Test plan

- Manual testing
- Updated unit tests