### PR TITLE
chore: Exclude dev dependencies from source clear check

### DIFF
--- a/srcclr.yml
+++ b/srcclr.yml
@@ -1,0 +1,1 @@
+scope: production


### PR DESCRIPTION
## Summary
Source clear was also checking for vulnerabilities in dev dependencies. Added a `srcclr.yml` file with `scope:production` to ignore checking dev dependencies.

## Test Plan
Source clear tests now show zero vulnerabilites.