### PR TITLE
Improve types for passing user attributes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -43,7 +43,7 @@ export interface ReactSDKClient extends optimizely.Client {
   user: UserContext;
 
   onReady(opts?: { timeout?: number }): Promise<any>;
-  setUser(userInfo: { id: string; attributes?: { [key: string]: any } }): void;
+  setUser(userInfo: { id: string; attributes?: { [key: string]: string | number | boolean | null } }): void;
   onUserUpdate(handler: OnUserUpdateHandler): DisposeFn;
   isReady(): boolean;
 


### PR DESCRIPTION
Passing `undefined` as a value in the attributes object to `setUser` results in a runtime error and experiments failing to load.

This is (kind of) stated [in the documentation](https://docs.developers.optimizely.com/full-stack/docs/pass-in-audience-attributes-react):

> You can pass strings, numbers, Booleans, and null as user attribute values

This PR properly types `setUser` so that this constraint is correctly held.
