### PR TITLE
chore: Update optimizely-sdk to 4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@optimizely/js-sdk-logging": "^0.1.0",
-    "@optimizely/optimizely-sdk": "^4.5.0-beta",
+    "@optimizely/optimizely-sdk": "^4.5.0",
     "hoist-non-react-statics": "^3.3.0",
     "prop-types": "^15.6.2",
     "utility-types": "^2.1.0 || ^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -506,10 +506,10 @@
   dependencies:
     uuid "^3.3.2"
 
-"@optimizely/optimizely-sdk@^4.5.0-beta":
-  version "4.5.0-beta"
-  resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-4.5.0-beta.tgz#69bbb82ab6abac9d56ed7e581aacabda3332d855"
-  integrity sha512-7lleaatiuBBwW2YL8WXylo7NB6vB7t02npSrqd4iuKDc7114xJogrNq0nGQgLw48SgYbY6pHFL2ipDCNIZ3f5w==
+"@optimizely/optimizely-sdk@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-4.5.0.tgz#af85693b38662d0036e2b819426d11fc038dd7e0"
+  integrity sha512-d9dYXfncDDXlBZ1pFsqNkwO7rTBHuEQGVE3pWd3lIsddpaCWEo+lf5j6F3CzvECbi2moVRtBYaIpo8PzKNRGJw==
   dependencies:
     "@optimizely/js-sdk-datafile-manager" "^0.8.0"
     "@optimizely/js-sdk-event-processor" "^0.8.0"


### PR DESCRIPTION
Update optimizely-sdk dependency to 4.5.0. This brings in the decide API functionality.