### PR TITLE
fix: Update VariableValuesObject type to handle JSON type variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Bug fixes
+- Update `VariableValuesObject` type to handle JSON type variable.
+
 ## [2.6.2] - July 15th, 2021
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Bug fixes
-- Update `VariableValuesObject` type to handle JSON type variable.
+- Update `VariableValuesObject` type to handle JSON type variable ([#118](https://github.com/optimizely/react-sdk/pull/118)).
 
 ## [2.6.2] - July 15th, 2021
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ The following type definitions are used in the `ReactSDKClient` interface:
 
 - `UserAttributes : { [name: string]: any }`
 - `User : { id: string | null, attributes: userAttributes }`
-- `VariableValuesObject : { [key: string]: unknown }`
+- `VariableValuesObject : { [key: string]: any }`
 - `EventTags : { [key: string]: string | number | boolean; }`
 
 `ReactSDKClient` instances have the methods/properties listed below. Note that in general, the API largely matches that of the core `@optimizely/optimizely-sdk` client instance, which is documented on the [Optimizely X Full Stack developer docs site](https://docs.developers.optimizely.com/full-stack/docs). The major exception is that, for most methods, user id & attributes are **_optional_** arguments. `ReactSDKClient` has a current user. This user's id & attributes are automatically applied to all method calls, and overrides can be provided as arguments to these method calls if desired.

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ The following type definitions are used in the `ReactSDKClient` interface:
 
 - `UserAttributes : { [name: string]: any }`
 - `User : { id: string | null, attributes: userAttributes }`
-- `VariableValuesObject : { [key: string]: boolean | number | string | null }`
+- `VariableValuesObject : { [key: string]: unknown }`
 - `EventTags : { [key: string]: string | number | boolean; }`
 
 `ReactSDKClient` instances have the methods/properties listed below. Note that in general, the API largely matches that of the core `@optimizely/optimizely-sdk` client instance, which is documented on the [Optimizely X Full Stack developer docs site](https://docs.developers.optimizely.com/full-stack/docs). The major exception is that, for most methods, user id & attributes are **_optional_** arguments. `ReactSDKClient` has a current user. This user's id & attributes are automatically applied to all method calls, and overrides can be provided as arguments to these method calls if desired.

--- a/src/client.ts
+++ b/src/client.ts
@@ -21,7 +21,7 @@ import { OptimizelyDecision, UserInfo, createFailedDecision } from './utils';
 const logger = logging.getLogger('ReactSDK');
 
 export type VariableValuesObject = {
-  [key: string]: unknown;
+  [key: string]: any;
 };
 
 type DisposeFn = () => void;

--- a/src/client.ts
+++ b/src/client.ts
@@ -21,7 +21,7 @@ import { OptimizelyDecision, UserInfo, createFailedDecision } from './utils';
 const logger = logging.getLogger('ReactSDK');
 
 export type VariableValuesObject = {
-  [key: string]: boolean | number | string | null;
+  [key: string]: unknown;
 };
 
 type DisposeFn = () => void;
@@ -475,7 +475,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
       return {};
     }
     const userAttributes = user.attributes;
-    const variableObj: { [key: string]: any } = {};
+    const variableObj: VariableValuesObject = {};
     const optlyConfig = this._client.getOptimizelyConfig();
     if (!optlyConfig) {
       return {};


### PR DESCRIPTION
## Summary

Update VariableValuesObject interface to handle JSON type variable.


Issue: https://github.com/optimizely/react-sdk/issues/117