### PR TITLE
chore: Prepare for 2.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.7.0] - September 16th, 2021
+Upgrade `@optimizely/optimizely-sdk` to [4.7.0](https://github.com/optimizely/javascript-sdk/releases/tag/v4.7.0):
+ - Added new public properties to `OptimizelyConfig` . See [@optimizely/optimizely-sdk Release 4.7.0](https://github.com/optimizely/javascript-sdk/releases/tag/v4.7.0) for details
+ - Deprecated `OptimizelyFeature.experimentsMap` of `OptimizelyConfig`. See [@optimizely/optimizely-sdk Release 4.7.0](https://github.com/optimizely/javascript-sdk/releases/tag/v4.7.0) for details
+ - For more information, refer to our documentation page: [https://docs.developers.optimizely.com/full-stack/v4.0/docs/optimizelyconfig-react](https://docs.developers.optimizely.com/full-stack/v4.0/docs/optimizelyconfig-react)
+
 ## [2.6.3] - July 29th, 2021
 
 ### Bug fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/react-sdk",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "description": "React SDK for Optimizely Full Stack and Optimizely Rollouts",
   "homepage": "https://github.com/optimizely/react-sdk",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@optimizely/js-sdk-logging": "^0.1.0",
-    "@optimizely/optimizely-sdk": "^4.6.2",
+    "@optimizely/optimizely-sdk": "^4.7.0",
     "hoist-non-react-statics": "^3.3.0",
     "prop-types": "^15.6.2",
     "utility-types": "^2.1.0 || ^3.0.0"

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -100,7 +100,7 @@ describe('ReactSDKClient', () => {
     expect(createInstanceSpy).toBeCalledWith({
       ...config,
       clientEngine: 'react-sdk',
-      clientVersion: '2.6.3',
+      clientVersion: '2.7.0',
     });
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -37,7 +37,7 @@ export type OnReadyResult = {
 };
 
 const REACT_SDK_CLIENT_ENGINE = 'react-sdk';
-const REACT_SDK_CLIENT_VERSION = '2.6.3';
+const REACT_SDK_CLIENT_VERSION = '2.7.0';
 
 export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserContext'> {
   user: UserInfo;

--- a/yarn.lock
+++ b/yarn.lock
@@ -506,10 +506,10 @@
   dependencies:
     uuid "^3.3.2"
 
-"@optimizely/optimizely-sdk@^4.6.2":
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-4.6.2.tgz#2f6ed23d88970f9f3420286f93ed6120dfcf14ea"
-  integrity sha512-ohXLafoShX6i5daZWbu+hHpAtw8i9QTOiwkHMRNIwBc70fcTDpUwl0UXsGbyJAmF1rTgcIknvqZKifVXLr/hgg==
+"@optimizely/optimizely-sdk@^4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-4.7.0.tgz#4f05368e1fd23e642da2606d8c23e7759af3b0ed"
+  integrity sha512-62XfmRGOiJOBP9LQ7bTVu4okTKiHVOx22Mv8p3gxetJINdqcL508JrBgAMiWe8bueuR4pfS2/orstAsceAVCsw==
   dependencies:
     "@optimizely/js-sdk-datafile-manager" "^0.8.1"
     "@optimizely/js-sdk-event-processor" "^0.8.2"


### PR DESCRIPTION
## Summary
- upgrate `optimizely-sdk` to [v4.7.0](https://github.com/optimizely/javascript-sdk/releases/tag/v4.7.0)
- prepare for 2.7.0 release