### PR TITLE
fix: Fixed redundant re-rendering issues

### DIFF
--- a/src/Experiment.spec.tsx
+++ b/src/Experiment.spec.tsx
@@ -55,6 +55,8 @@ describe('<OptimizelyExperiment>', () => {
         attributes: {},
       },
       isReady: jest.fn().mockImplementation(() => isReady),
+      getIsReadyPromiseFulfilled: () => true,
+      getIsUsingSdkKey: () => true,
       onForcedVariationsUpdate: jest.fn().mockReturnValue(() => {}),
     } as unknown) as ReactSDKClient;
   });

--- a/src/Experiment.spec.tsx
+++ b/src/Experiment.spec.tsx
@@ -16,6 +16,7 @@
 /// <reference types="jest" />
 import * as React from 'react';
 import * as Enzyme from 'enzyme';
+import { act } from 'react-dom/test-utils';
 import Adapter from 'enzyme-adapter-react-16';
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -30,8 +31,10 @@ describe('<OptimizelyExperiment>', () => {
   const variationKey = 'variationResult';
   let resolver: any;
   let optimizelyMock: ReactSDKClient;
+  let isReady: boolean;
 
   beforeEach(() => {
+    isReady = false;
     const onReadyPromise = new Promise((resolve, reject) => {
       resolver = {
         reject,
@@ -51,7 +54,7 @@ describe('<OptimizelyExperiment>', () => {
         id: 'testuser',
         attributes: {},
       },
-      isReady: jest.fn().mockReturnValue(false),
+      isReady: jest.fn().mockImplementation(() => isReady),
       onForcedVariationsUpdate: jest.fn().mockReturnValue(() => {}),
     } as unknown) as ReactSDKClient;
   });
@@ -282,8 +285,8 @@ describe('<OptimizelyExperiment>', () => {
 
       // Simulate client becoming ready
       resolver.resolve({ success: true });
-
-      await optimizelyMock.onReady();
+      isReady = true;
+      await act(async () => await optimizelyMock.onReady());
 
       component.update();
 
@@ -321,8 +324,8 @@ describe('<OptimizelyExperiment>', () => {
 
       // Simulate client becoming ready
       resolver.resolve({ success: true });
-
-      await optimizelyMock.onReady();
+      isReady = true;
+      await act(async () => await optimizelyMock.onReady());
 
       component.update();
 

--- a/src/Feature.spec.tsx
+++ b/src/Feature.spec.tsx
@@ -15,6 +15,7 @@
  */
 import * as React from 'react';
 import * as Enzyme from 'enzyme';
+import { act } from 'react-dom/test-utils';
 import Adapter from 'enzyme-adapter-react-16';
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -27,11 +28,13 @@ describe('<OptimizelyFeature>', () => {
   let resolver: any;
   let optimizelyMock: ReactSDKClient;
   const isEnabledMock = true;
+  let isReady: boolean;
   const featureVariables = {
     foo: 'bar',
   };
 
   beforeEach(() => {
+    isReady = false;
     const onReadyPromise = new Promise((resolve, reject) => {
       resolver = {
         reject,
@@ -52,7 +55,7 @@ describe('<OptimizelyFeature>', () => {
         id: 'testuser',
         attributes: {},
       },
-      isReady: jest.fn().mockReturnValue(false),
+      isReady: jest.fn().mockImplementation(() => isReady),
     } as unknown) as ReactSDKClient;
   });
   it('throws an error when not rendered in the context of an OptimizelyProvider', () => {
@@ -209,7 +212,8 @@ describe('<OptimizelyFeature>', () => {
         // Simulate client becoming ready
         resolver.resolve({ success: true });
 
-        await optimizelyMock.onReady();
+        isReady = true;
+        await act(async () => await optimizelyMock.onReady());
 
         component.update();
 
@@ -226,7 +230,7 @@ describe('<OptimizelyFeature>', () => {
         }));
 
         const updateFn = (optimizelyMock.notificationCenter.addNotificationListener as jest.Mock).mock.calls[0][1];
-        updateFn();
+        act(updateFn);
 
         component.update();
 
@@ -253,7 +257,8 @@ describe('<OptimizelyFeature>', () => {
         // Simulate client becoming ready
         resolver.resolve({ success: true });
 
-        await optimizelyMock.onReady();
+        isReady = true;
+        await act(async () => await optimizelyMock.onReady());
 
         component.update();
 
@@ -269,7 +274,7 @@ describe('<OptimizelyFeature>', () => {
           foo: 'baz',
         }));
 
-        updateFn();
+        act(updateFn);
 
         component.update();
 

--- a/src/Feature.spec.tsx
+++ b/src/Feature.spec.tsx
@@ -56,6 +56,8 @@ describe('<OptimizelyFeature>', () => {
         attributes: {},
       },
       isReady: jest.fn().mockImplementation(() => isReady),
+      getIsReadyPromiseFulfilled: () => true,
+      getIsUsingSdkKey: () => true,
     } as unknown) as ReactSDKClient;
   });
   it('throws an error when not rendered in the context of an OptimizelyProvider', () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -218,12 +218,12 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
 
     this._client.onReady().then(() => {
       this.isClientReady = true;
-
-      // Client can become ready synchronously and/or asynchronously. This flag specifically indicates that it became ready asynchronously.
-      this.isReadyPromiseFulfilled = true;
     });
 
-    this.dataReadyPromise = Promise.all([this.userPromise, this._client.onReady()]).then(() => {      
+    this.dataReadyPromise = Promise.all([this.userPromise, this._client.onReady()]).then(() => {
+
+      // Client and user can become ready synchronously and/or asynchronously. This flag specifically indicates that they became ready asynchronously.
+      this.isReadyPromiseFulfilled = true;
       return {
         success: true,
         reason: 'datafile and user resolved',

--- a/src/client.ts
+++ b/src/client.ts
@@ -173,9 +173,16 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
   private onUserUpdateHandlers: OnUserUpdateHandler[] = [];
   private onForcedVariationsUpdateHandlers: OnForcedVariationsUpdateHandler[] = [];
 
+  // Is the javascript SDK instance ready.
   private isClientReady: boolean = false;
+
+  // We need to add autoupdate listener to the hooks after the instance became fully ready to avoid redundant updates to hooks
   private isReadyPromiseFulfilled: boolean = false;
+
+  // Its usually true from the beginning when user is provided as an object in the `OptimizelyProvider`
+  // This becomes more significant when a promise is provided instead.
   private isUserReady: boolean = false;
+
   private isUsingSdkKey: boolean = false;
 
   private readonly _client: optimizely.Client;
@@ -211,6 +218,8 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
 
     this._client.onReady().then(() => {
       this.isClientReady = true;
+
+      // Client can become ready synchronously and/or asynchronously. This flag specifically indicates that it became ready asynchronously.
       this.isReadyPromiseFulfilled = true;
     });
 
@@ -299,6 +308,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
   }
 
   isReady(): boolean {
+    // React SDK Instance only becomes ready when both JS SDK client and the user info is ready.
     return this.isUserReady && this.isClientReady;
   }
 

--- a/src/hooks.spec.tsx
+++ b/src/hooks.spec.tsx
@@ -118,6 +118,8 @@ describe('hooks', () => {
         attributes: {},
       },
       isReady: () => readySuccess,
+      getIsReadyPromiseFulfilled: () => true,
+      getIsUsingSdkKey: () => true,
       onForcedVariationsUpdate: jest.fn().mockImplementation(handler => {
         forcedVariationUpdateCallbacks.push(handler);
         return () => {};

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -384,7 +384,7 @@ export const useDecision: UseDecision = (flagKey, options = {}, overrides = {}) 
   }, [isClientReady, finalReadyTimeout, getCurrentDecision, optimizely]);
 
   useEffect(() => {
-    if (options.autoUpdate) {
+    if (isClientReady && options.autoUpdate) {
       return setupAutoUpdateListeners(optimizely, HookType.FEATURE, flagKey, hooksLogger, () => {
         setState(prevState => ({
           ...prevState,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -210,7 +210,8 @@ export const useExperiment: UseExperiment = (experimentKey, options = {}, overri
 
   const finalReadyTimeout = options.timeout !== undefined ? options.timeout : timeout;
   useEffect(() => {
-    if (!isClientReady) {
+    // Subscribe to the first ready promise only when sdkKey is being used.
+    if (optimizely.getIsUsingSdkKey()) {
       subscribeToInitialization(optimizely, finalReadyTimeout, initState => {
         setState({
           ...getCurrentDecision(),
@@ -218,10 +219,11 @@ export const useExperiment: UseExperiment = (experimentKey, options = {}, overri
         });
       });
     }
-  }, [isClientReady, finalReadyTimeout, getCurrentDecision, optimizely]);
+  }, []);
 
   useEffect(() => {
-    if (isClientReady && options.autoUpdate) {
+    // Subscribe to update after first datafile is fetched and readyPromise is resolved.
+    if (optimizely.getIsReadyPromiseFulfilled() && options.autoUpdate) {
       return setupAutoUpdateListeners(optimizely, HookType.EXPERIMENT, experimentKey, hooksLogger, () => {
         setState(prevState => ({
           ...prevState,
@@ -230,7 +232,7 @@ export const useExperiment: UseExperiment = (experimentKey, options = {}, overri
       });
     }
     return (): void => {};
-  }, [isClientReady, options.autoUpdate, optimizely, experimentKey, getCurrentDecision]);
+  }, [optimizely.getIsReadyPromiseFulfilled(), options.autoUpdate, optimizely, experimentKey, getCurrentDecision]);
 
   useEffect(
     () =>
@@ -297,7 +299,8 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
 
   const finalReadyTimeout = options.timeout !== undefined ? options.timeout : timeout;
   useEffect(() => {
-    if (!isClientReady) {
+    // Subscribe to the first ready promise only when sdkKey is being used.
+    if (optimizely.getIsUsingSdkKey()) {
       subscribeToInitialization(optimizely, finalReadyTimeout, initState => {
         setState({
           ...getCurrentDecision(),
@@ -305,10 +308,11 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
         });
       });
     }
-  }, [isClientReady, finalReadyTimeout, getCurrentDecision, optimizely]);
+  }, []);
 
   useEffect(() => {
-    if (isClientReady && options.autoUpdate) {
+    // Subscribe to update after first datafile is fetched and readyPromise is resolved.
+    if (optimizely.getIsReadyPromiseFulfilled() && options.autoUpdate) {
       return setupAutoUpdateListeners(optimizely, HookType.FEATURE, featureKey, hooksLogger, () => {
         setState(prevState => ({
           ...prevState,
@@ -317,7 +321,7 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
       });
     }
     return (): void => {};
-  }, [isClientReady, options.autoUpdate, optimizely, featureKey, getCurrentDecision]);
+  }, [optimizely.getIsReadyPromiseFulfilled(), options.autoUpdate, optimizely, featureKey, getCurrentDecision]);
 
   return [state.isEnabled, state.variables, state.clientReady, state.didTimeout];
 };
@@ -373,7 +377,8 @@ export const useDecision: UseDecision = (flagKey, options = {}, overrides = {}) 
 
   const finalReadyTimeout = options.timeout !== undefined ? options.timeout : timeout;
   useEffect(() => {
-    if (!isClientReady) {
+    // Subscribe to the first ready promise only when sdkKey is being used.
+    if (optimizely.getIsUsingSdkKey()) {
       subscribeToInitialization(optimizely, finalReadyTimeout, initState => {
         setState({
           ...getCurrentDecision(),
@@ -381,10 +386,11 @@ export const useDecision: UseDecision = (flagKey, options = {}, overrides = {}) 
         });
       });
     }
-  }, [isClientReady, finalReadyTimeout, getCurrentDecision, optimizely]);
+  }, []);
 
   useEffect(() => {
-    if (isClientReady && options.autoUpdate) {
+    // Subscribe to update after first datafile is fetched and readyPromise is resolved.
+    if (optimizely.getIsReadyPromiseFulfilled() && options.autoUpdate) {
       return setupAutoUpdateListeners(optimizely, HookType.FEATURE, flagKey, hooksLogger, () => {
         setState(prevState => ({
           ...prevState,
@@ -393,7 +399,7 @@ export const useDecision: UseDecision = (flagKey, options = {}, overrides = {}) 
       });
     }
     return (): void => {};
-  }, [isClientReady, options.autoUpdate, optimizely, flagKey, getCurrentDecision]);
+  }, [optimizely.getIsReadyPromiseFulfilled(), options.autoUpdate, optimizely, flagKey, getCurrentDecision]);
 
   return [state.decision, state.clientReady, state.didTimeout];
 };

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -210,8 +210,7 @@ export const useExperiment: UseExperiment = (experimentKey, options = {}, overri
 
   const finalReadyTimeout = options.timeout !== undefined ? options.timeout : timeout;
   useEffect(() => {
-    // Subscribe to the first ready promise only when sdkKey is being used.
-    if (optimizely.getIsUsingSdkKey()) {
+    if (optimizely.getIsUsingSdkKey() || !isClientReady) {
       subscribeToInitialization(optimizely, finalReadyTimeout, initState => {
         setState({
           ...getCurrentDecision(),
@@ -299,8 +298,7 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
 
   const finalReadyTimeout = options.timeout !== undefined ? options.timeout : timeout;
   useEffect(() => {
-    // Subscribe to the first ready promise only when sdkKey is being used.
-    if (optimizely.getIsUsingSdkKey()) {
+    if (optimizely.getIsUsingSdkKey() || !isClientReady) {
       subscribeToInitialization(optimizely, finalReadyTimeout, initState => {
         setState({
           ...getCurrentDecision(),
@@ -377,8 +375,7 @@ export const useDecision: UseDecision = (flagKey, options = {}, overrides = {}) 
 
   const finalReadyTimeout = options.timeout !== undefined ? options.timeout : timeout;
   useEffect(() => {
-    // Subscribe to the first ready promise only when sdkKey is being used.
-    if (optimizely.getIsUsingSdkKey()) {
+    if (optimizely.getIsUsingSdkKey() || !isClientReady) {
       subscribeToInitialization(optimizely, finalReadyTimeout, initState => {
         setState({
           ...getCurrentDecision(),

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -221,7 +221,7 @@ export const useExperiment: UseExperiment = (experimentKey, options = {}, overri
   }, [isClientReady, finalReadyTimeout, getCurrentDecision, optimizely]);
 
   useEffect(() => {
-    if (options.autoUpdate) {
+    if (isClientReady && options.autoUpdate) {
       return setupAutoUpdateListeners(optimizely, HookType.EXPERIMENT, experimentKey, hooksLogger, () => {
         setState(prevState => ({
           ...prevState,
@@ -308,7 +308,7 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
   }, [isClientReady, finalReadyTimeout, getCurrentDecision, optimizely]);
 
   useEffect(() => {
-    if (options.autoUpdate) {
+    if (isClientReady && options.autoUpdate) {
       return setupAutoUpdateListeners(optimizely, HookType.FEATURE, featureKey, hooksLogger, () => {
         setState(prevState => ({
           ...prevState,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -210,6 +210,11 @@ export const useExperiment: UseExperiment = (experimentKey, options = {}, overri
 
   const finalReadyTimeout = options.timeout !== undefined ? options.timeout : timeout;
   useEffect(() => {
+    // Subscribe to initialzation promise only
+    // 1. When client is using Sdk Key, which means the initialization will be asynchronous
+    //    and we need to wait for the promise and update decision.
+    // 2. When client is using datafile only but client is not ready yet which means user
+    //    was provided as a promise and we need to subscribe and wait for user to become available.
     if (optimizely.getIsUsingSdkKey() || !isClientReady) {
       subscribeToInitialization(optimizely, finalReadyTimeout, initState => {
         setState({
@@ -221,7 +226,7 @@ export const useExperiment: UseExperiment = (experimentKey, options = {}, overri
   }, []);
 
   useEffect(() => {
-    // Subscribe to update after first datafile is fetched and readyPromise is resolved.
+    // Subscribe to update after first datafile is fetched and readyPromise is resolved to avoid redundant rendering.
     if (optimizely.getIsReadyPromiseFulfilled() && options.autoUpdate) {
       return setupAutoUpdateListeners(optimizely, HookType.EXPERIMENT, experimentKey, hooksLogger, () => {
         setState(prevState => ({
@@ -298,6 +303,11 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
 
   const finalReadyTimeout = options.timeout !== undefined ? options.timeout : timeout;
   useEffect(() => {
+    // Subscribe to initialzation promise only
+    // 1. When client is using Sdk Key, which means the initialization will be asynchronous
+    //    and we need to wait for the promise and update decision.
+    // 2. When client is using datafile only but client is not ready yet which means user
+    //    was provided as a promise and we need to subscribe and wait for user to become available.
     if (optimizely.getIsUsingSdkKey() || !isClientReady) {
       subscribeToInitialization(optimizely, finalReadyTimeout, initState => {
         setState({
@@ -309,7 +319,7 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
   }, []);
 
   useEffect(() => {
-    // Subscribe to update after first datafile is fetched and readyPromise is resolved.
+    // Subscribe to update after first datafile is fetched and readyPromise is resolved to avoid redundant rendering.
     if (optimizely.getIsReadyPromiseFulfilled() && options.autoUpdate) {
       return setupAutoUpdateListeners(optimizely, HookType.FEATURE, featureKey, hooksLogger, () => {
         setState(prevState => ({
@@ -375,6 +385,11 @@ export const useDecision: UseDecision = (flagKey, options = {}, overrides = {}) 
 
   const finalReadyTimeout = options.timeout !== undefined ? options.timeout : timeout;
   useEffect(() => {
+    // Subscribe to initialzation promise only
+    // 1. When client is using Sdk Key, which means the initialization will be asynchronous
+    //    and we need to wait for the promise and update decision.
+    // 2. When client is using datafile only but client is not ready yet which means user 
+    //    was provided as a promise and we need to subscribe and wait for user to become available.
     if (optimizely.getIsUsingSdkKey() || !isClientReady) {
       subscribeToInitialization(optimizely, finalReadyTimeout, initState => {
         setState({
@@ -386,7 +401,7 @@ export const useDecision: UseDecision = (flagKey, options = {}, overrides = {}) 
   }, []);
 
   useEffect(() => {
-    // Subscribe to update after first datafile is fetched and readyPromise is resolved.
+    // Subscribe to update after first datafile is fetched and readyPromise is resolved to avoid redundant rendering.
     if (optimizely.getIsReadyPromiseFulfilled() && options.autoUpdate) {
       return setupAutoUpdateListeners(optimizely, HookType.FEATURE, flagKey, hooksLogger, () => {
         setState(prevState => ({


### PR DESCRIPTION
## Summary
Made the following re-rendering fixes.
1. When SDK is initialized using a datafile, hooks were doing an empty first render and the real decision was returned on the second render. Fixed the SDK to render the correct decision on first render when initialized synchronously.
2. When SDK is initialized with datafile and SDK key both, The hook was being evaluated three times instead of two. Fixed the redundant re-rendering in this case.

Also checked the SDK thoroughly in many combination of sync/async intialization parameters and made fixes where needed.

## Test Plan
1. All unit tests pass.
2. Tested all the hooks and components thoroughly with hard coded data file, SDK key and both along with async/sync user initialzation and autoUpdate true/false.