### PR TITLE
fix user overrides: merge overrides with current user attributes

### DIFF
--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -205,6 +205,7 @@ describe('ReactSDKClient', () => {
         expect(result).toBe('var2');
         expect(mockInnerClient.activate).toBeCalledTimes(1);
         expect(mockInnerClient.activate).toBeCalledWith('exp1', 'user2', {
+          foo: 'bar',
           bar: 'baz',
         });
       });
@@ -218,7 +219,7 @@ describe('ReactSDKClient', () => {
 
         instance.track('evt1', 'user2', { bar: 'baz' });
         expect(mockFn).toBeCalledTimes(1);
-        expect(mockFn).toBeCalledWith('evt1', 'user2', { bar: 'baz' }, undefined);
+        expect(mockFn).toBeCalledWith('evt1', 'user2', { foo: 'bar', bar: 'baz' }, undefined);
         mockFn.mockReset();
 
         // Use pre-set user with event tags
@@ -230,7 +231,7 @@ describe('ReactSDKClient', () => {
         // Use overrides with event tags
         instance.track('evt1', 'user3', { bla: 'bla' }, { tagKey: 'tagVal' });
         expect(mockFn).toBeCalledTimes(1);
-        expect(mockFn).toBeCalledWith('evt1', 'user3', { bla: 'bla' }, { tagKey: 'tagVal' });
+        expect(mockFn).toBeCalledWith('evt1', 'user3', { foo: 'bar', bla: 'bla' }, { tagKey: 'tagVal' });
       });
 
       it('can use pre-set and override user for isFeatureEnabled', () => {
@@ -248,6 +249,7 @@ describe('ReactSDKClient', () => {
         expect(result).toBe(false);
         expect(mockFn).toBeCalledTimes(1);
         expect(mockFn).toBeCalledWith('feat1', 'user2', {
+          foo: 'bar',
           bar: 'baz',
         });
       });
@@ -267,6 +269,7 @@ describe('ReactSDKClient', () => {
         expect(result).toEqual(['feat1', 'feat2']);
         expect(mockFn).toBeCalledTimes(1);
         expect(mockFn).toBeCalledWith('user2', {
+          foo: 'bar',
           bar: 'baz',
         });
       });
@@ -286,6 +289,7 @@ describe('ReactSDKClient', () => {
         expect(result).toEqual('var2');
         expect(mockFn).toBeCalledTimes(1);
         expect(mockFn).toBeCalledWith('exp1', 'user2', {
+          foo: 'bar',
           bar: 'baz',
         });
       });
@@ -307,6 +311,7 @@ describe('ReactSDKClient', () => {
         expect(result).toBe(true);
         expect(mockFn).toBeCalledTimes(1);
         expect(mockFn).toBeCalledWith('feat1', 'bvar1', 'user2', {
+          foo: 'bar',
           bar: 'baz',
         });
       });
@@ -328,6 +333,7 @@ describe('ReactSDKClient', () => {
         expect(result).toBe('varval2');
         expect(mockFn).toBeCalledTimes(1);
         expect(mockFn).toBeCalledWith('feat1', 'svar1', 'user2', {
+          foo: 'bar',
           bar: 'baz',
         });
       });
@@ -349,6 +355,7 @@ describe('ReactSDKClient', () => {
         expect(result).toBe(-20);
         expect(mockFn).toBeCalledTimes(1);
         expect(mockFn).toBeCalledWith('feat1', 'ivar1', 'user2', {
+          foo: 'bar',
           bar: 'baz',
         });
       });
@@ -369,7 +376,10 @@ describe('ReactSDKClient', () => {
         });
         expect(result).toBe(-20.2);
         expect(mockInnerClient.getFeatureVariableDouble).toBeCalledTimes(1);
-        expect(mockInnerClient.getFeatureVariableDouble).toBeCalledWith('feat1', 'dvar1', 'user2', { bar: 'baz' });
+        expect(mockInnerClient.getFeatureVariableDouble).toBeCalledWith('feat1', 'dvar1', 'user2', {
+          foo: 'bar',
+          bar: 'baz',
+        });
       });
 
       it('can use pre-set and override user for getFeatureVariableJSON', () => {
@@ -400,7 +410,10 @@ describe('ReactSDKClient', () => {
           text: 'variable value',
         });
         expect(mockInnerClient.getFeatureVariableJSON).toBeCalledTimes(1);
-        expect(mockInnerClient.getFeatureVariableJSON).toBeCalledWith('feat1', 'dvar1', 'user2', { bar: 'baz' });
+        expect(mockInnerClient.getFeatureVariableJSON).toBeCalledWith('feat1', 'dvar1', 'user2', {
+          foo: 'bar',
+          bar: 'baz',
+        });
       });
 
       it('can use pre-set and override user for getFeatureVariable', () => {
@@ -431,7 +444,10 @@ describe('ReactSDKClient', () => {
           text: 'variable value',
         });
         expect(mockInnerClient.getFeatureVariable).toBeCalledTimes(1);
-        expect(mockInnerClient.getFeatureVariable).toBeCalledWith('feat1', 'dvar1', 'user2', { bar: 'baz' });
+        expect(mockInnerClient.getFeatureVariable).toBeCalledWith('feat1', 'dvar1', 'user2', {
+          foo: 'bar',
+          bar: 'baz',
+        });
       });
 
       it('can use pre-set and override user for setForcedVariation', () => {
@@ -512,21 +528,21 @@ describe('ReactSDKClient', () => {
           ruleKey: '',
           userContext: {
             id: 'user2',
-            attributes: { bar: 'baz' },
+            attributes: { foo: 'bar', bar: 'baz' },
           },
           variables: {},
           variationKey: 'varition2',
         });
         expect(mockFn).toBeCalledTimes(1);
         expect(mockFn).toBeCalledWith('exp1', [optimizely.OptimizelyDecideOption.INCLUDE_REASONS]);
-        expect(mockCreateUserContext).toBeCalledWith('user2', { bar: 'baz' });
+        expect(mockCreateUserContext).toBeCalledWith('user2', { foo: 'bar', bar: 'baz' });
       });
 
       it('can use pre-set and override user for decideAll', () => {
         const mockFn = mockOptimizelyUserContext.decideAll as jest.Mock;
         const mockCreateUserContext = mockInnerClient.createUserContext as jest.Mock;
         mockFn.mockReturnValue({
-          'theFlag1': {
+          theFlag1: {
             enabled: true,
             flagKey: 'theFlag1',
             reasons: [],
@@ -534,11 +550,11 @@ describe('ReactSDKClient', () => {
             userContext: mockOptimizelyUserContext,
             variables: {},
             variationKey: 'varition1',
-          }
+          },
         });
         let result = instance.decideAll();
         expect(result).toEqual({
-          'theFlag1': {
+          theFlag1: {
             enabled: true,
             flagKey: 'theFlag1',
             reasons: [],
@@ -549,14 +565,14 @@ describe('ReactSDKClient', () => {
             },
             variables: {},
             variationKey: 'varition1',
-          }
+          },
         });
         expect(mockFn).toBeCalledTimes(1);
         expect(mockFn).toBeCalledWith([]);
-        expect(mockCreateUserContext).toBeCalledWith('user1', { foo: 'bar' });        
+        expect(mockCreateUserContext).toBeCalledWith('user1', { foo: 'bar' });
         mockFn.mockReset();
         mockFn.mockReturnValue({
-          'theFlag2': {
+          theFlag2: {
             enabled: true,
             flagKey: 'theFlag2',
             reasons: [],
@@ -564,33 +580,33 @@ describe('ReactSDKClient', () => {
             userContext: mockOptimizelyUserContext,
             variables: {},
             variationKey: 'varition2',
-          }
+          },
         });
         result = instance.decideAll([optimizely.OptimizelyDecideOption.INCLUDE_REASONS], 'user2', { bar: 'baz' });
         expect(result).toEqual({
-          'theFlag2': {
+          theFlag2: {
             enabled: true,
             flagKey: 'theFlag2',
             reasons: [],
             ruleKey: '',
             userContext: {
               id: 'user2',
-              attributes: { bar: 'baz' },
+              attributes: { foo: 'bar', bar: 'baz' },
             },
             variables: {},
             variationKey: 'varition2',
-          }
+          },
         });
         expect(mockFn).toBeCalledTimes(1);
         expect(mockFn).toBeCalledWith([optimizely.OptimizelyDecideOption.INCLUDE_REASONS]);
-        expect(mockCreateUserContext).toBeCalledWith('user2', { bar: 'baz' });
+        expect(mockCreateUserContext).toBeCalledWith('user2', { foo: 'bar', bar: 'baz' });
       });
 
       it('can use pre-set and override user for decideForKeys', () => {
         const mockFn = mockOptimizelyUserContext.decideForKeys as jest.Mock;
         const mockCreateUserContext = mockInnerClient.createUserContext as jest.Mock;
         mockFn.mockReturnValue({
-          'theFlag1': {
+          theFlag1: {
             enabled: true,
             flagKey: 'theFlag1',
             reasons: [],
@@ -598,11 +614,11 @@ describe('ReactSDKClient', () => {
             userContext: mockOptimizelyUserContext,
             variables: {},
             variationKey: 'varition1',
-          }
+          },
         });
         let result = instance.decideForKeys(['theFlag1']);
         expect(result).toEqual({
-          'theFlag1': {
+          theFlag1: {
             enabled: true,
             flagKey: 'theFlag1',
             reasons: [],
@@ -613,14 +629,14 @@ describe('ReactSDKClient', () => {
             },
             variables: {},
             variationKey: 'varition1',
-          }
+          },
         });
         expect(mockFn).toBeCalledTimes(1);
         expect(mockFn).toBeCalledWith(['theFlag1'], []);
         expect(mockCreateUserContext).toBeCalledWith('user1', { foo: 'bar' });
         mockFn.mockReset();
         mockFn.mockReturnValue({
-          'theFlag2': {
+          theFlag2: {
             enabled: true,
             flagKey: 'theFlag2',
             reasons: [],
@@ -628,26 +644,28 @@ describe('ReactSDKClient', () => {
             userContext: mockOptimizelyUserContext,
             variables: {},
             variationKey: 'varition2',
-          }
+          },
         });
-        result = instance.decideForKeys(['theFlag1'], [optimizely.OptimizelyDecideOption.INCLUDE_REASONS], 'user2', { bar: 'baz' });
+        result = instance.decideForKeys(['theFlag1'], [optimizely.OptimizelyDecideOption.INCLUDE_REASONS], 'user2', {
+          bar: 'baz',
+        });
         expect(result).toEqual({
-          'theFlag2': {
+          theFlag2: {
             enabled: true,
             flagKey: 'theFlag2',
             reasons: [],
             ruleKey: '',
             userContext: {
               id: 'user2',
-              attributes: { bar: 'baz' },
+              attributes: { foo: 'bar', bar: 'baz' },
             },
             variables: {},
             variationKey: 'varition2',
-          }
+          },
         });
         expect(mockFn).toBeCalledTimes(1);
         expect(mockFn).toBeCalledWith(['theFlag1'], [optimizely.OptimizelyDecideOption.INCLUDE_REASONS]);
-        expect(mockCreateUserContext).toBeCalledWith('user2', { bar: 'baz' });
+        expect(mockCreateUserContext).toBeCalledWith('user2', { foo: 'bar', bar: 'baz' });
       });
     });
 
@@ -824,7 +842,7 @@ describe('ReactSDKClient', () => {
           },
         });
         expect(mockInnerClient.getAllFeatureVariables).toBeCalledTimes(1);
-        expect(mockInnerClient.getAllFeatureVariables).toBeCalledWith('feat1', 'user2', { bar: 'baz' });
+        expect(mockInnerClient.getAllFeatureVariables).toBeCalledWith('feat1', 'user2', { foo: 'bar', bar: 'baz' });
       });
     });
   });

--- a/src/client.ts
+++ b/src/client.ts
@@ -143,27 +143,27 @@ export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserConte
     options?: optimizely.OptimizelyDecideOption[],
     overrideUserId?: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): OptimizelyDecision
+  ): OptimizelyDecision;
 
   decideAll(
     options?: optimizely.OptimizelyDecideOption[],
     overrideUserId?: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): { [key: string]: OptimizelyDecision }
+  ): { [key: string]: OptimizelyDecision };
 
   decideForKeys(
     keys: string[],
     options?: optimizely.OptimizelyDecideOption[],
     overrideUserId?: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): { [key: string]: OptimizelyDecision }
+  ): { [key: string]: OptimizelyDecision };
 }
 
 export const DEFAULT_ON_READY_TIMEOUT = 5000;
 
 class OptimizelyReactSDKClient implements ReactSDKClient {
   public initialConfig: optimizely.Config;
-  public user: UserInfo = { 
+  public user: UserInfo = {
     id: null,
     attributes: {},
   };
@@ -174,16 +174,16 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
   private onForcedVariationsUpdateHandlers: OnForcedVariationsUpdateHandler[] = [];
 
   // Is the javascript SDK instance ready.
-  private isClientReady: boolean = false;
+  private isClientReady = false;
 
   // We need to add autoupdate listener to the hooks after the instance became fully ready to avoid redundant updates to hooks
-  private isReadyPromiseFulfilled: boolean = false;
+  private isReadyPromiseFulfilled = false;
 
   // Its usually true from the beginning when user is provided as an object in the `OptimizelyProvider`
   // This becomes more significant when a promise is provided instead.
-  private isUserReady: boolean = false;
+  private isUserReady = false;
 
-  private isUsingSdkKey: boolean = false;
+  private isUsingSdkKey = false;
 
   private readonly _client: optimizely.Client;
 
@@ -213,7 +213,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
       this.userPromiseResolver = resolve;
     }).then(() => {
       this.isUserReady = true;
-      return { success: true }
+      return { success: true };
     });
 
     this._client.onReady().then(() => {
@@ -221,7 +221,6 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     });
 
     this.dataReadyPromise = Promise.all([this.userPromise, this._client.onReady()]).then(() => {
-
       // Client and user can become ready synchronously and/or asynchronously. This flag specifically indicates that they became ready asynchronously.
       this.isReadyPromiseFulfilled = true;
       return {
@@ -231,7 +230,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     });
   }
 
-  getIsReadyPromiseFulfilled(): boolean { 
+  getIsReadyPromiseFulfilled(): boolean {
     return this.isReadyPromiseFulfilled;
   }
 
@@ -338,21 +337,24 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     options: optimizely.OptimizelyDecideOption[] = [],
     overrideUserId?: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): OptimizelyDecision {    
+  ): OptimizelyDecision {
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
     if (user.id === null) {
       logger.info('Not Evaluating feature "%s" because userId is not set', key);
       return createFailedDecision(key, `Not Evaluating flag ${key} because userId is not set`, user);
-    }    
-    const optlyUserContext: optimizely.OptimizelyUserContext | null = this._client.createUserContext(user.id, user.attributes);
+    }
+    const optlyUserContext: optimizely.OptimizelyUserContext | null = this._client.createUserContext(
+      user.id,
+      user.attributes
+    );
     if (optlyUserContext) {
       return {
-        ... optlyUserContext.decide(key, options),
+        ...optlyUserContext.decide(key, options),
         userContext: {
           id: user.id,
-          attributes: user.attributes
-        }
-      }
+          attributes: user.attributes,
+        },
+      };
     }
     return createFailedDecision(key, `Not Evaluating flag ${key} because user id or attributes are not valid`, user);
   }
@@ -367,25 +369,30 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     if (user.id === null) {
       logger.info('Not Evaluating features because userId is not set');
       return {};
-    }    
-    const optlyUserContext: optimizely.OptimizelyUserContext | null = this._client.createUserContext(user.id, user.attributes);
+    }
+    const optlyUserContext: optimizely.OptimizelyUserContext | null = this._client.createUserContext(
+      user.id,
+      user.attributes
+    );
     if (optlyUserContext) {
-      return Object.entries(optlyUserContext.decideForKeys(keys, options))
-        .reduce((decisions: { [key: string]: OptimizelyDecision }, [key, decision]) => {
+      return Object.entries(optlyUserContext.decideForKeys(keys, options)).reduce(
+        (decisions: { [key: string]: OptimizelyDecision }, [key, decision]) => {
           decisions[key] = {
-            ... decision,
+            ...decision,
             userContext: {
               id: user.id || '',
               attributes: user.attributes,
-            }
-          }
+            },
+          };
           return decisions;
-        }, {});
+        },
+        {}
+      );
     }
     return {};
   }
 
-  public decideAll(    
+  public decideAll(
     options: optimizely.OptimizelyDecideOption[] = [],
     overrideUserId?: string,
     overrideAttributes?: optimizely.UserAttributes
@@ -394,20 +401,25 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     if (user.id === null) {
       logger.info('Not Evaluating features because userId is not set');
       return {};
-    }    
-    const optlyUserContext: optimizely.OptimizelyUserContext | null = this._client.createUserContext(user.id, user.attributes);
+    }
+    const optlyUserContext: optimizely.OptimizelyUserContext | null = this._client.createUserContext(
+      user.id,
+      user.attributes
+    );
     if (optlyUserContext) {
-      return Object.entries(optlyUserContext.decideAll(options))
-        .reduce((decisions: { [key: string]: OptimizelyDecision }, [key, decision]) => {
+      return Object.entries(optlyUserContext.decideAll(options)).reduce(
+        (decisions: { [key: string]: OptimizelyDecision }, [key, decision]) => {
           decisions[key] = {
-            ... decision,
+            ...decision,
             userContext: {
               id: user.id || '',
               attributes: user.attributes,
-            }
-          }
+            },
+          };
           return decisions;
-        }, {});
+        },
+        {}
+      );
     }
     return {};
   }
@@ -780,8 +792,13 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     overrideAttributes?: optimizely.UserAttributes
   ): UserInfo {
     const finalUserId: string | null = overrideUserId === undefined ? this.user.id : overrideUserId;
-    const finalUserAttributes: optimizely.UserAttributes | undefined =
-      overrideAttributes === undefined ? this.user.attributes : overrideAttributes;
+    const hasOverrides = overrideAttributes !== undefined;
+
+    const overrides = hasOverrides ? overrideAttributes : {};
+    const combinedAttributes = { ...this.user.attributes, ...overrides };
+    const finalUserAttributes: optimizely.UserAttributes | undefined = hasOverrides
+      ? combinedAttributes
+      : this.user.attributes;
 
     return {
       id: finalUserId,

--- a/src/hooks.spec.tsx
+++ b/src/hooks.spec.tsx
@@ -47,7 +47,9 @@ const MyExperimentComponent = ({ options = {}, overrides = {} }: any) => {
 
 const MyDecideComponent = ({ options = {}, overrides = {} }: any) => {
   const [decision, clientReady, didTimeout] = useDecision('feature1', { ...options }, { ...overrides });
-  return <>{`${(decision.enabled) ? 'true' : 'false'}|${JSON.stringify(decision.variables)}|${clientReady}|${didTimeout}`}</>;
+  return (
+    <>{`${decision.enabled ? 'true' : 'false'}|${JSON.stringify(decision.variables)}|${clientReady}|${didTimeout}`}</>
+  );
 };
 
 const mockFeatureVariables: VariableValuesObject = {
@@ -673,9 +675,9 @@ describe('hooks', () => {
   describe('useDecision', () => {
     it('should render true when the flag is enabled', async () => {
       decideMock.mockReturnValue({
-        ... defaultDecision,
+        ...defaultDecision,
         enabled: true,
-        variables: { 'foo': 'bar' },        
+        variables: { foo: 'bar' },
       });
       const component = Enzyme.mount(
         <OptimizelyProvider optimizely={optimizelyMock}>
@@ -687,11 +689,11 @@ describe('hooks', () => {
       expect(component.text()).toBe('true|{"foo":"bar"}|true|false');
     });
 
-    it('should render false when the flag is disabled', async () => {    
+    it('should render false when the flag is disabled', async () => {
       decideMock.mockReturnValue({
-        ... defaultDecision,
+        ...defaultDecision,
         enabled: false,
-        variables: { 'foo': 'bar' },        
+        variables: { foo: 'bar' },
       });
       const component = Enzyme.mount(
         <OptimizelyProvider optimizely={optimizelyMock}>
@@ -704,7 +706,7 @@ describe('hooks', () => {
     });
 
     it('should respect the timeout option passed', async () => {
-      decideMock.mockReturnValue({ ... defaultDecision });
+      decideMock.mockReturnValue({ ...defaultDecision });
       readySuccess = false;
 
       const component = Enzyme.mount(
@@ -721,26 +723,26 @@ describe('hooks', () => {
       // Simulate datafile fetch completing after timeout has already passed
       // flag is now true and decision contains variables
       decideMock.mockReturnValue({
-        ... defaultDecision,
+        ...defaultDecision,
         enabled: true,
-        variables: { 'foo': 'bar' },
+        variables: { foo: 'bar' },
       });
 
       await optimizelyMock.onReady().then(res => res.dataReadyPromise);
       component.update();
 
-      // Simulate datafile fetch completing after timeout has already passed      
+      // Simulate datafile fetch completing after timeout has already passed
       // Wait for completion of dataReadyPromise
       await optimizelyMock.onReady().then(res => res.dataReadyPromise);
       component.update();
-      
+
       expect(component.text()).toBe('true|{"foo":"bar"}|true|true'); // when clientReady
     });
 
     it('should gracefully handle the client promise rejecting after timeout', async () => {
-      console.log('hola')
+      console.log('hola');
       readySuccess = false;
-      decideMock.mockReturnValue({ ... defaultDecision });
+      decideMock.mockReturnValue({ ...defaultDecision });
       getOnReadyPromise = () =>
         new Promise((res, rej) => {
           setTimeout(() => rej('some error with user'), mockDelay);
@@ -773,7 +775,7 @@ describe('hooks', () => {
       decideMock.mockReturnValue({
         ...defaultDecision,
         enabled: true,
-        variables: { 'foo': 'bar' }
+        variables: { foo: 'bar' },
       });
       // Simulate the user object changing
       act(() => {
@@ -800,8 +802,8 @@ describe('hooks', () => {
       decideMock.mockReturnValue({
         ...defaultDecision,
         enabled: true,
-        variables: { 'foo': 'bar' }
-      });      
+        variables: { foo: 'bar' },
+      });
       // Simulate the user object changing
       act(() => {
         userUpdateCallbacks.forEach(fn => fn());
@@ -899,7 +901,7 @@ describe('hooks', () => {
       component.update();
       expect(component.text()).toBe('true|{}|true|false');
 
-      decideMock.mockReturnValue({ ...defaultDecision, enabled: false, variables: { myvar: 3 } });      
+      decideMock.mockReturnValue({ ...defaultDecision, enabled: false, variables: { myvar: 3 } });
       component.setProps({
         children: (
           <MyDecideComponent

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -350,15 +350,21 @@ export const useDecision: UseDecision = (flagKey, options = {}, overrides = {}) 
   const overrideAttrs = useCompareAttrsMemoize(overrides.overrideAttributes);
   const getCurrentDecision: () => { decision: OptimizelyDecision } = useCallback(
     () => ({
-      decision: optimizely.decide(flagKey, options.decideOptions, overrides.overrideUserId, overrideAttrs)
+      decision: optimizely.decide(flagKey, options.decideOptions, overrides.overrideUserId, overrideAttrs),
     }),
     [optimizely, flagKey, overrides.overrideUserId, overrideAttrs, options.decideOptions]
   );
 
   const isClientReady = isServerSide || optimizely.isReady();
   const [state, setState] = useState<{ decision: OptimizelyDecision } & InitializationState>(() => {
-    const decisionState = isClientReady? getCurrentDecision()
-      : { decision: createFailedDecision(flagKey, 'Optimizely SDK not configured properly yet.', { id: overrides.overrideUserId || null, attributes: overrideAttrs}) };
+    const decisionState = isClientReady
+      ? getCurrentDecision()
+      : {
+          decision: createFailedDecision(flagKey, 'Optimizely SDK not configured properly yet.', {
+            id: overrides.overrideUserId || null,
+            attributes: overrideAttrs,
+          }),
+        };
     return {
       ...decisionState,
       clientReady: isClientReady,
@@ -388,7 +394,7 @@ export const useDecision: UseDecision = (flagKey, options = {}, overrides = {}) 
     // Subscribe to initialzation promise only
     // 1. When client is using Sdk Key, which means the initialization will be asynchronous
     //    and we need to wait for the promise and update decision.
-    // 2. When client is using datafile only but client is not ready yet which means user 
+    // 2. When client is using datafile only but client is not ready yet which means user
     //    was provided as a promise and we need to subscribe and wait for user to become available.
     if (optimizely.getIsUsingSdkKey() || !isClientReady) {
       subscribeToInitialization(optimizely, finalReadyTimeout, initState => {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -24,8 +24,8 @@ export type UserInfo = {
 };
 
 export interface OptimizelyDecision extends Omit<optimizely.OptimizelyDecision, 'userContext'> {
-   userContext: UserInfo
-};
+  userContext: UserInfo;
+}
 
 export function areUsersEqual(user1: UserInfo, user2: UserInfo): boolean {
   if (user1.id !== user2.id) {
@@ -37,8 +37,8 @@ export function areUsersEqual(user1: UserInfo, user2: UserInfo): boolean {
   user1keys.sort();
   user2keys.sort();
 
-  const user1Attributes = user1.attributes || {}
-  const user2Attributes = user2.attributes || {}
+  const user1Attributes = user1.attributes || {};
+  const user2Attributes = user2.attributes || {};
 
   const areKeysLenEqual = user1keys.length === user2keys.length;
   if (!areKeysLenEqual) {
@@ -119,7 +119,7 @@ export function createFailedDecision(flagKey: string, message: string, user: Use
     reasons: [message],
     userContext: {
       id: user.id,
-      attributes: user.attributes
-    }
-  }
+      attributes: user.attributes,
+    },
+  };
 }


### PR DESCRIPTION
This pull request addresses the issue that is laid out by my colleague @dtothefp here: optimizely#120

It will merge the existing user attributes with the current user's attributes to prevent losing the user attributes that are set when the optimizely client is initialized.