### PR TITLE
avoid throwing in react hooks if the optimizely client is not available from the context

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -24,7 +24,7 @@ import { areUsersEqual, UserInfo } from './utils';
 const logger = getLogger('<OptimizelyProvider>');
 
 interface OptimizelyProviderProps {
-  optimizely: ReactSDKClient;
+  optimizely: ReactSDKClient | null;
   timeout?: number;
   isServerSide?: boolean;
   user?: Promise<UserInfo> | UserInfo;
@@ -41,6 +41,10 @@ export class OptimizelyProvider extends React.Component<OptimizelyProviderProps,
   constructor(props: OptimizelyProviderProps) {
     super(props);
     const { optimizely, userId, userAttributes, user } = props;
+
+    if (!optimizely) {
+      return;
+    }
 
     // check if user id/attributes are provided as props and set them ReactSDKClient
     let finalUser: UserInfo | null = null;
@@ -76,6 +80,11 @@ export class OptimizelyProvider extends React.Component<OptimizelyProviderProps,
       return;
     }
     const { optimizely } = this.props;
+
+    if (!optimizely) {
+      return;
+    }
+
     if (this.props.user && 'id' in this.props.user) {
       if (!optimizely.user.id) {
         // no user is set in optimizely, update


### PR DESCRIPTION
this allows an application to catch a thrown error from `createInstance` and use `null` as a fallback for the OptimizelyProvider, keeping the application working instead of crashing.

see #134 for more info

fixes #134