### PR TITLE
fix: Exported correct type from `createInstance`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -168,6 +168,9 @@ export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserConte
   removeAllForcedDecisions(): boolean;
 
   removeForcedDecision(decisionContext: optimizely.OptimizelyDecisionContext): boolean;
+
+  initialConfig: optimizely.Config;
+  client : optimizely.Client;
 }
 
 export const DEFAULT_ON_READY_TIMEOUT = 5000;

--- a/src/client.ts
+++ b/src/client.ts
@@ -921,8 +921,6 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
   }
 }
 
-export function createInstance(config: optimizely.Config): OptimizelyReactSDKClient {
+export function createInstance(config: optimizely.Config): ReactSDKClient {
   return new OptimizelyReactSDKClient(config);
 }
-
-export type OptimizelyReactSDKClientType = OptimizelyReactSDKClient; 

--- a/src/client.ts
+++ b/src/client.ts
@@ -924,3 +924,5 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
 export function createInstance(config: optimizely.Config): OptimizelyReactSDKClient {
   return new OptimizelyReactSDKClient(config);
 }
+
+export type OptimizelyReactSDKClientType = OptimizelyReactSDKClient; 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,6 @@ export {
   OptimizelyDecideOption,
 } from '@optimizely/optimizely-sdk';
 
-export { createInstance, ReactSDKClient } from './client';
+export { createInstance, ReactSDKClient, OptimizelyReactSDKClientType } from './client';
 
 export { default as logOnlyEventDispatcher } from './logOnlyEventDispatcher';

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,6 @@ export {
   OptimizelyDecideOption,
 } from '@optimizely/optimizely-sdk';
 
-export { createInstance, ReactSDKClient, OptimizelyReactSDKClientType } from './client';
+export { createInstance, ReactSDKClient } from './client';
 
 export { default as logOnlyEventDispatcher } from './logOnlyEventDispatcher';


### PR DESCRIPTION
## Summary
Return type of `createInstance` was `OptimizelyReactSDKClient` which is the implementation class. Changed it to the `ReactSDKClient` interface instead.

## Test Plan
- Manually tested thoroughly.
- All existing unit tests pass.

## Issues
Probably fixed #49 