### PR TITLE
refactor: Return `ReactSDKClient` interface from `createInstance` instead of implementation class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Enhancements
+- fixed issue [#49](https://github.com/optimizely/react-sdk/issues/49): Return type of `createInstance` was `OptimizelyReactSDKClient` which is the implementation class. Changed it to the `ReactSDKClient` interface instead ([#148](https://github.com/optimizely/react-sdk/pull/148)).
+
 ## [2.8.0] - January 26, 2022
 
 ### New Features

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -18,6 +18,10 @@ jest.mock('@optimizely/optimizely-sdk');
 import * as optimizely from '@optimizely/optimizely-sdk';
 
 import { createInstance, OnReadyResult, ReactSDKClient } from './client';
+interface MockedReactSDKClient extends ReactSDKClient {
+  client: optimizely.Client;
+  initialConfig: optimizely.Config;
+}
 
 describe('ReactSDKClient', () => {
   const config: optimizely.Config = {
@@ -79,7 +83,7 @@ describe('ReactSDKClient', () => {
 
   it('provides the initial config object via the initialConfig property', () => {
     const instance = createInstance(config);
-    expect(instance.initialConfig).toEqual(config);
+    expect((instance as MockedReactSDKClient).initialConfig).toEqual(config);
   });
 
   it('provides a default user object', () => {
@@ -94,7 +98,7 @@ describe('ReactSDKClient', () => {
     const instance = createInstance(config);
     expect(createInstanceSpy).toBeCalledTimes(1);
     expect(createInstanceSpy.mock.results[0].type).toBe('return');
-    expect(createInstanceSpy.mock.results[0].value).toBe(instance.client);
+    expect(createInstanceSpy.mock.results[0].value).toBe((instance as MockedReactSDKClient).client);
   });
 
   it('adds react-sdk clientEngine and clientVersion to the config, and passed the config to createInstance', () => {
@@ -109,7 +113,7 @@ describe('ReactSDKClient', () => {
 
   it('provides access to the underlying client notificationCenter', () => {
     const instance = createInstance(config);
-    expect(instance.notificationCenter).toBe(instance.client.notificationCenter);
+    expect(instance.notificationCenter).toBe((instance as MockedReactSDKClient).client.notificationCenter);
   });
 
   describe('onReady', () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -168,6 +168,9 @@ export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserConte
   removeAllForcedDecisions(): boolean;
 
   removeForcedDecision(decisionContext: optimizely.OptimizelyDecisionContext): boolean;
+
+  initialConfig: optimizely.Config;
+  client : optimizely.Client;
 }
 
 export const DEFAULT_ON_READY_TIMEOUT = 5000;

--- a/src/client.ts
+++ b/src/client.ts
@@ -169,6 +169,9 @@ export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserConte
 
   removeForcedDecision(decisionContext: optimizely.OptimizelyDecisionContext): boolean;
 
+  notificationCenter: optimizely.NotificationCenter;
+
+  getForcedDecision(decisionContext: optimizely.OptimizelyDecisionContext): optimizely.OptimizelyForcedDecision | null;
 }
 
 export const DEFAULT_ON_READY_TIMEOUT = 5000;

--- a/src/client.ts
+++ b/src/client.ts
@@ -921,8 +921,6 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
   }
 }
 
-export function createInstance(config: optimizely.Config): OptimizelyReactSDKClient {
+export function createInstance(config: optimizely.Config): ReactSDKClient {
   return new OptimizelyReactSDKClient(config);
 }
-
-export type OptimizelyReactSDKClientType = OptimizelyReactSDKClient; 

--- a/src/client.ts
+++ b/src/client.ts
@@ -169,8 +169,6 @@ export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserConte
 
   removeForcedDecision(decisionContext: optimizely.OptimizelyDecisionContext): boolean;
 
-  notificationCenter: optimizely.NotificationCenter;
-
   getForcedDecision(decisionContext: optimizely.OptimizelyDecisionContext): optimizely.OptimizelyForcedDecision | null;
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -924,3 +924,5 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
 export function createInstance(config: optimizely.Config): OptimizelyReactSDKClient {
   return new OptimizelyReactSDKClient(config);
 }
+
+export type OptimizelyReactSDKClientType = OptimizelyReactSDKClient; 

--- a/src/client.ts
+++ b/src/client.ts
@@ -169,8 +169,6 @@ export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserConte
 
   removeForcedDecision(decisionContext: optimizely.OptimizelyDecisionContext): boolean;
 
-  initialConfig: optimizely.Config;
-  client : optimizely.Client;
 }
 
 export const DEFAULT_ON_READY_TIMEOUT = 5000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,6 @@ export {
   OptimizelyDecideOption,
 } from '@optimizely/optimizely-sdk';
 
-export { createInstance, ReactSDKClient } from './client';
+export { createInstance, ReactSDKClient, OptimizelyReactSDKClientType } from './client';
 
 export { default as logOnlyEventDispatcher } from './logOnlyEventDispatcher';

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,6 @@ export {
   OptimizelyDecideOption,
 } from '@optimizely/optimizely-sdk';
 
-export { createInstance, ReactSDKClient, OptimizelyReactSDKClientType } from './client';
+export { createInstance, ReactSDKClient } from './client';
 
 export { default as logOnlyEventDispatcher } from './logOnlyEventDispatcher';


### PR DESCRIPTION
### Summary
Return type of createInstance was OptimizelyReactSDKClient which is the implementation class. Changed it to the ReactSDKClient interface instead.

### Test Plan

- Manually tested thoroughly.
- All existing unit tests pass.

### Issues
#49 