### PR TITLE
fix: React SDK null client handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - fixed issue [#121](https://github.com/optimizely/react-sdk/issues/121):`ActivateListenerPayload` and `TrackListenerPayload` types were exported from `@optimizely/optimizely-sdk` but were missing from `@optimizely/react-sdk` exports. ([#150](https://github.com/optimizely/react-sdk/pull/150)).
 
+### Bug fixes
+- Fixed issue [#134](https://github.com/optimizely/react-sdk/issues/134) of the React SDK crashing when the internal Optimizely client returns as a null value. [PR #149](https://github.com/optimizely/react-sdk/pull/149)
+
 ## [2.8.0] - January 26, 2022
 
 ### New Features

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -117,14 +117,17 @@ describe('ReactSDKClient', () => {
   });
 
   describe('onReady', () => {
+    let instance: ReactSDKClient;
+    beforeEach(() => {
+      instance = createInstance(config);
+    });
+
     it('fulfills the returned promise with success: false when the timeout expires, and no user is set', async () => {
-      const instance = createInstance(config);
       const result = await instance.onReady({ timeout: 1 });
       expect(result.success).toBe(false);
     });
 
     it('fulfills the returned promise with success: true when a user is set', async () => {
-      const instance = createInstance(config);
       instance.setUser({
         id: 'user12345',
       });
@@ -132,14 +135,50 @@ describe('ReactSDKClient', () => {
       expect(result.success).toBe(true);
     });
 
-    it('waits for the inner client onReady to fulfill before fulfilling the returned promise', async () => {
+    describe('if Optimizely client is null', () => {
+      beforeEach(() => {
+        // Mocks dataReadyPromise value instead of _client = null because test initialization of instance causes dataReadyPromise to return { success: true }
+        // @ts-ignore
+        instance.dataReadyPromise = new Promise((resolve, reject) => {
+          resolve({
+            success: false,
+            reason: 'NO_CLIENT',
+            reasonDetail: 'Optimizely client failed to initialize.',
+          });
+        });
+      });
+
+      it('fulfills the returned promise with success: false when a user is set', async () => {
+        instance.setUser({
+          id: 'user12345',
+        });
+        const result = await instance.onReady();
+        expect(result.success).toBe(false);
+      });
+
+      it('waits for the inner client onReady to fulfill with success = false before fulfilling the returned promise', async () => {
+        const mockInnerClientOnReady = jest.spyOn(mockInnerClient, 'onReady');
+        let resolveInnerClientOnReady: (result: OnReadyResult) => void;
+        const mockReadyPromise: Promise<OnReadyResult> = new Promise(res => {
+          resolveInnerClientOnReady = res;
+        });
+        mockInnerClientOnReady.mockReturnValueOnce(mockReadyPromise);
+        instance.setUser({
+          id: 'user999',
+        });
+        resolveInnerClientOnReady!({ success: true });
+        const result = await instance.onReady();
+        expect(result.success).toBe(false);
+      });
+    });
+
+    it('waits for the inner client onReady to fulfill with success = true before fulfilling the returned promise', async () => {
       const mockInnerClientOnReady = jest.spyOn(mockInnerClient, 'onReady');
       let resolveInnerClientOnReady: (result: OnReadyResult) => void;
       const mockReadyPromise: Promise<OnReadyResult> = new Promise(res => {
         resolveInnerClientOnReady = res;
       });
       mockInnerClientOnReady.mockReturnValueOnce(mockReadyPromise);
-      const instance = createInstance(config);
       instance.setUser({
         id: 'user999',
       });
@@ -197,6 +236,137 @@ describe('ReactSDKClient', () => {
         });
         const mockFn = mockInnerClient.getEnabledFeatures as jest.Mock;
         mockFn.mockReturnValue(['feat1', 'feat2']);
+      });
+
+      describe('if Optimizely client is null', () => {
+        beforeEach(() => {
+          // @ts-ignore
+          instance._client = null;
+        });
+
+        it('cannot use pre-set or override user for activate', () => {
+          const mockFn = mockInnerClient.activate as jest.Mock;
+          mockFn.mockReturnValue('var1');
+          const result = instance.activate('exp1');
+          expect(result).toBe(null);
+        });
+
+        it('cannot use pre-set or override user for track', () => {
+          const mockFn = mockInnerClient.track as jest.Mock;
+          instance.track('evt1');
+          expect(mockFn).toBeCalledTimes(0);
+        });
+
+        it('cannot use pre-set or override user for isFeatureEnabled', () => {
+          const mockFn = mockInnerClient.isFeatureEnabled as jest.Mock;
+          mockFn.mockReturnValue(true);
+          const result = instance.isFeatureEnabled('feat1');
+          expect(result).toBe(false);
+        });
+
+        it('cannot use pre-set and override user for getEnabledFeatures', () => {
+          const mockFn = mockInnerClient.getEnabledFeatures as jest.Mock;
+          mockFn.mockReturnValue(['feat1']);
+          const result = instance.getEnabledFeatures();
+          expect(result).toEqual([]);
+        });
+
+        it('cannot use pre-set or override user for getVariation', () => {
+          const mockFn = mockInnerClient.getVariation as jest.Mock;
+          mockFn.mockReturnValue('var1');
+          const result = instance.getVariation('exp1');
+          expect(result).toEqual(null);
+        });
+
+        it('cannot use pre-set or override user for getFeatureVariableBoolean', () => {
+          const mockFn = mockInnerClient.getFeatureVariableBoolean as jest.Mock;
+          mockFn.mockReturnValue(false);
+          const result = instance.getFeatureVariableBoolean('feat1', 'bvar1');
+          expect(result).toBe(null);
+        });
+
+        it('cannot use pre-set or override user for getFeatureVariableString', () => {
+          const mockFn = mockInnerClient.getFeatureVariableString as jest.Mock;
+          mockFn.mockReturnValue('varval1');
+          const result = instance.getFeatureVariableString('feat1', 'svar1');
+          expect(result).toBe(null);
+        });
+
+        it('cannot use pre-set or override user for getFeatureVariableInteger', () => {
+          const mockFn = mockInnerClient.getFeatureVariableInteger as jest.Mock;
+          mockFn.mockReturnValue(15);
+          const result = instance.getFeatureVariableInteger('feat1', 'ivar1');
+          expect(result).toBe(null);
+        });
+
+        it('cannot use pre-set or override user for getFeatureVariableDouble', () => {
+          const mockFn = mockInnerClient.getFeatureVariableDouble as jest.Mock;
+          mockFn.mockReturnValue(15.5);
+          const result = instance.getFeatureVariableDouble('feat1', 'dvar1');
+          expect(result).toBe(null);
+        });
+
+        it('cannot use pre-set or override user for getFeatureVariableJSON', () => {
+          const mockFn = mockInnerClient.getFeatureVariableJSON as jest.Mock;
+          mockFn.mockReturnValue({
+            num_buttons: 0,
+            text: 'default value',
+          });
+          const result = instance.getFeatureVariableJSON('feat1', 'dvar1');
+          expect(result).toEqual(null);
+        });
+
+        it('cannot use pre-set or override user for getFeatureVariable', () => {
+          const mockFn = mockInnerClient.getFeatureVariable as jest.Mock;
+          mockFn.mockReturnValue({
+            num_buttons: 0,
+            text: 'default value',
+          });
+          const result = instance.getFeatureVariable('feat1', 'dvar1', 'user1');
+          expect(result).toEqual(null);
+        });
+
+        it('cannot use pre-set or override user for setForcedVariation', () => {
+          const mockFn = mockInnerClient.setForcedVariation as jest.Mock;
+          mockFn.mockReturnValue(true);
+          const result = instance.setForcedVariation('exp1', 'var1');
+          expect(result).toBe(false);
+        });
+
+        it('cannot use pre-set or override user for getForcedVariation', () => {
+          const mockFn = mockInnerClient.getForcedVariation as jest.Mock;
+          mockFn.mockReturnValue('var1');
+          const result = instance.getForcedVariation('exp1');
+          expect(result).toBe(null);
+        });
+
+        it('cannot use pre-set or override user for decide', () => {
+          const mockFn = mockOptimizelyUserContext.decide as jest.Mock;
+          mockFn.mockReturnValue({
+            enabled: true,
+            flagKey: 'theFlag1',
+            reasons: [],
+            ruleKey: '',
+            userContext: mockOptimizelyUserContext,
+            variables: {},
+            variationKey: 'varition1',
+          });
+          const result = instance.decide('exp1');
+          expect(result).toEqual({
+            enabled: false,
+            flagKey: 'exp1',
+            reasons: ['Unable to evaluate flag exp1 because Optimizely client failed to initialize.'],
+            ruleKey: null,
+            userContext: {
+              attributes: {
+                foo: 'bar',
+              },
+              id: 'user1',
+            },
+            variables: {},
+            variationKey: null,
+          });
+        });
       });
 
       it('can use pre-set and override user for activate', () => {
@@ -529,6 +699,28 @@ describe('ReactSDKClient', () => {
         expect(mockCreateUserContext).toBeCalledWith('user2', { bar: 'baz' });
       });
 
+      describe('if Optimizely client is null', () => {
+        it('cannot use pre-set or override user for decideAll', () => {
+          const mockFn = mockOptimizelyUserContext.decideAll as jest.Mock;
+          const mockCreateUserContext = mockInnerClient.createUserContext as jest.Mock;
+          mockFn.mockReturnValue({
+            theFlag1: {
+              enabled: true,
+              flagKey: 'theFlag1',
+              reasons: [],
+              ruleKey: '',
+              userContext: mockOptimizelyUserContext,
+              variables: {},
+              variationKey: 'varition1',
+            },
+          });
+          // @ts-ignore
+          instance._client = null;
+          const result = instance.decideAll();
+          expect(result).toEqual({});
+        });
+      });
+
       it('can use pre-set and override user for decideAll', () => {
         const mockFn = mockOptimizelyUserContext.decideAll as jest.Mock;
         const mockCreateUserContext = mockInnerClient.createUserContext as jest.Mock;
@@ -591,6 +783,28 @@ describe('ReactSDKClient', () => {
         expect(mockFn).toBeCalledTimes(1);
         expect(mockFn).toBeCalledWith([optimizely.OptimizelyDecideOption.INCLUDE_REASONS]);
         expect(mockCreateUserContext).toBeCalledWith('user2', { bar: 'baz' });
+      });
+
+      describe('if Optimizely client is null', () => {
+        it('cannot use pre-set or override user for decideForKeys', () => {
+          const mockFn = mockOptimizelyUserContext.decideForKeys as jest.Mock;
+          const mockCreateUserContext = mockInnerClient.createUserContext as jest.Mock;
+          mockFn.mockReturnValue({
+            theFlag1: {
+              enabled: true,
+              flagKey: 'theFlag1',
+              reasons: [],
+              ruleKey: '',
+              userContext: mockOptimizelyUserContext,
+              variables: {},
+              variationKey: 'varition1',
+            },
+          });
+          // @ts-ignore
+          instance._client = null;
+          const result = instance.decideForKeys(['theFlag1']);
+          expect(result).toEqual({});
+        });
       });
 
       it('can use pre-set and override user for decideForKeys', () => {
@@ -668,6 +882,75 @@ describe('ReactSDKClient', () => {
         expect(result).toEqual({});
       });
 
+      describe('if Optimizely client is null', () => {
+        it('does not return an object with variables of all types returned from the inner sdk ', () => {
+          (mockInnerClient.getOptimizelyConfig as jest.Mock).mockReturnValue({
+            featuresMap: {
+              feat1: {
+                variablesMap: {
+                  bvar: {
+                    id: '0',
+                    key: 'bvar',
+                    type: 'boolean',
+                    value: 'false',
+                  },
+                  svar: {
+                    id: '1',
+                    key: 'svar',
+                    type: 'string',
+                    value: '',
+                  },
+                  ivar: {
+                    id: '2',
+                    key: 'ivar',
+                    type: 'integer',
+                    value: '0',
+                  },
+                  dvar: {
+                    id: '3',
+                    key: 'dvar',
+                    type: 'double',
+                    value: '0',
+                  },
+                  jvar: {
+                    id: '4',
+                    key: 'jvar',
+                    type: 'json',
+                    value: '{}',
+                  },
+                },
+              },
+            },
+          });
+          (mockInnerClient.getFeatureVariable as jest.Mock).mockImplementation(
+            (featureKey: string, variableKey: string) => {
+              switch (variableKey) {
+                case 'bvar':
+                  return true;
+                case 'svar':
+                  return 'whatsup';
+                case 'ivar':
+                  return 10;
+                case 'dvar':
+                  return -10.5;
+                case 'jvar':
+                  return { value: 'json value' };
+                default:
+                  return null;
+              }
+            }
+          );
+          const instance = createInstance(config);
+          instance.setUser({
+            id: 'user1123',
+          });
+          // @ts-ignore
+          instance._client = null;
+          const result = instance.getFeatureVariables('feat1');
+          expect(result).toEqual({});
+        });
+      });
+
       it('returns an object with variables of all types returned from the inner sdk ', () => {
         (mockInnerClient.getOptimizelyConfig as jest.Mock).mockReturnValue({
           featuresMap: {
@@ -743,6 +1026,53 @@ describe('ReactSDKClient', () => {
     });
 
     describe('getAllFeatureVariables', () => {
+      describe('if Optimizely client is null', () => {
+        it('does not return an object with variables of all types returned from the inner sdk ', () => {
+          const anyClient = mockInnerClient.getAllFeatureVariables as jest.Mock;
+          anyClient.mockReturnValue({
+            bvar: true,
+            svar: 'whatsup',
+            ivar: 10,
+            dvar: -10.5,
+            jvar: {
+              value: 'json value',
+            },
+          });
+          const instance = createInstance(config);
+          // @ts-ignore
+          instance._client = null;
+          instance.setUser({
+            id: 'user1123',
+          });
+          const result = instance.getAllFeatureVariables('feat1', 'user1');
+          expect(result).toEqual({});
+        });
+
+        it('cannot use pre-set and override user for getAllFeatureVariables', () => {
+          const mockFn = mockInnerClient.getAllFeatureVariables as jest.Mock;
+          mockFn.mockReturnValue({
+            bvar: true,
+            svar: 'whatsup',
+            ivar: 10,
+            dvar: -10.5,
+            jvar: {
+              value: 'json value',
+            },
+          });
+          const instance = createInstance(config);
+          // @ts-ignore
+          instance._client = null;
+          instance.setUser({
+            id: 'user1',
+            attributes: {
+              foo: 'bar',
+            },
+          });
+          const result = instance.getAllFeatureVariables('feat1', 'user1');
+          expect(result).toEqual({});
+        });
+      });
+
       it('returns an empty object when the inner SDK returns no variables', () => {
         const anyClient = mockInnerClient.getAllFeatureVariables as jest.Mock;
         anyClient.mockReturnValue({});
@@ -850,6 +1180,17 @@ describe('ReactSDKClient', () => {
       });
     });
 
+    describe('if Optimizely client is null', () => {
+      it('does not call the handler function when setForcedVariation is called', () => {
+        // @ts-ignore
+        instance._client = null;
+        const handler = jest.fn();
+        instance.onForcedVariationsUpdate(handler);
+        instance.setForcedVariation('my_exp', 'xxfueaojfe8&86', 'variation_a');
+        expect(handler).toBeCalledTimes(0);
+      });
+    });
+
     it('calls the handler function when setForcedVariation is called', () => {
       const handler = jest.fn();
       instance.onForcedVariationsUpdate(handler);
@@ -882,6 +1223,24 @@ describe('ReactSDKClient', () => {
       expect(result).toEqual(false);
     });
 
+    describe('if Optimizely client is null', () => {
+      it('should return false', () => {
+        // @ts-ignore
+        instance._client = null;
+        instance.setUser({
+          id: 'user1',
+        });
+        const mockFn = mockOptimizelyUserContext.removeAllForcedDecisions as jest.Mock;
+
+        mockFn.mockReturnValue(true);
+
+        const result = instance.removeAllForcedDecisions();
+        expect(mockFn).toBeCalledTimes(0);
+        expect(result).toBeDefined();
+        expect(result).toEqual(false);
+      });
+    });
+
     it('should return true if  user context has been set ', () => {
       instance.setUser({
         id: 'user1',
@@ -906,6 +1265,38 @@ describe('ReactSDKClient', () => {
         attributes: {
           foo: 'bar',
         },
+      });
+    });
+
+    describe('when Optimizely client is null', () => {
+      it('should report an error', () => {
+        const mockFn = mockOptimizelyUserContext.decide as jest.Mock;
+        mockFn.mockReturnValue({
+          enabled: true,
+          flagKey: 'theFlag1',
+          reasons: [],
+          ruleKey: '',
+          userContext: mockOptimizelyUserContext,
+          variables: {},
+          variationKey: 'varition1',
+        });
+
+        // @ts-ignore
+        instance._client = null;
+
+        const result = instance.decide('theFlag1');
+        expect(result).toEqual({
+          enabled: false,
+          flagKey: 'theFlag1',
+          reasons: ['Unable to evaluate flag theFlag1 because Optimizely client failed to initialize.'],
+          ruleKey: null,
+          userContext: {
+            id: 'user1',
+            attributes: { foo: 'bar' },
+          },
+          variables: {},
+          variationKey: null,
+        });
       });
     });
 
@@ -983,6 +1374,38 @@ describe('ReactSDKClient', () => {
         attributes: {
           foo: 'bar',
         },
+      });
+    });
+
+    describe('when Optimizely client is null', () => {
+      it('should report flag evaluation error', () => {
+        const mockFn = mockOptimizelyUserContext.decide as jest.Mock;
+        mockFn.mockReturnValue({
+          enabled: true,
+          flagKey: 'theFlag1',
+          reasons: [],
+          ruleKey: '',
+          userContext: mockOptimizelyUserContext,
+          variables: {},
+          variationKey: 'varition1',
+        });
+
+        // @ts-ignore
+        instance._client = null;
+
+        const result = instance.decide('theFlag1');
+        expect(result).toEqual({
+          enabled: false,
+          flagKey: 'theFlag1',
+          reasons: ['Unable to evaluate flag theFlag1 because Optimizely client failed to initialize.'],
+          ruleKey: null,
+          userContext: {
+            id: 'user1',
+            attributes: { foo: 'bar' },
+          },
+          variables: {},
+          variationKey: null,
+        });
       });
     });
 

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -143,7 +143,7 @@ describe('ReactSDKClient', () => {
           resolve({
             success: false,
             reason: 'NO_CLIENT',
-            reasonDetail: 'Optimizely client failed to initialize.',
+            message: 'Optimizely client failed to initialize.',
           });
         });
       });

--- a/src/client.ts
+++ b/src/client.ts
@@ -312,13 +312,16 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
         userContext = this._client.createUserContext(userInfo.id, userInfo.attributes);
         return userContext;
       }
+
+      return null;
     }
 
     if (userInfo.id) {
       this.userContext = this._client.createUserContext(userInfo.id, userInfo.attributes);
+      return this.userContext;
     }
 
-    return this.userContext;
+    return null;
   }
 
   setUser(userInfo: UserInfo): void {

--- a/src/client.ts
+++ b/src/client.ts
@@ -248,11 +248,11 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
         this.isReadyPromiseFulfilled = true;
         return {
           success: true,
-          reason: 'datafile and user resolved',
+          reason: 'Successfully resolved datafile and user information.',
         };
       })
     } else {
-      logger.warn('Unable to resolve Data File and User information because Optimizely client failed to initialize.');
+      logger.warn('Unable to resolve datafile and user information because Optimizely client failed to initialize.');
 
       this.dataReadyPromise = new Promise((resolve, reject) => {
         resolve({
@@ -480,6 +480,11 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     overrideUserId?: string,
     overrideAttributes?: optimizely.UserAttributes
   ): { [key: string]: OptimizelyDecision } {
+    if (!this._client) {
+      logger.warn('Unable to evaluate all feature decisions because Optimizely client is not initialized.');
+      return {};
+    }
+
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
     if (user.id === null) {
       logger.warn('Unable to evaluate all feature decisions because User ID is not set');

--- a/src/client.ts
+++ b/src/client.ts
@@ -37,7 +37,7 @@ type NotReadyReason = 'TIMEOUT' | 'NO_CLIENT';
 export type OnReadyResult = {
   success: boolean;
   reason?: NotReadyReason;
-  reasonDetail?: string;
+  message?: string;
   dataReadyPromise?: Promise<any>;
 };
 
@@ -244,7 +244,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
         this.isReadyPromiseFulfilled = true;
         return {
           success: true,
-          reasonDetail: 'Successfully resolved datafile and user information.',
+          message: 'Successfully resolved datafile and user information.',
         };
       });
     } else {
@@ -254,7 +254,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
         resolve({
           success: false,
           reason: 'NO_CLIENT',
-          reasonDetail: 'Optimizely client failed to initialize.',
+          message: 'Optimizely client failed to initialize.',
         });
       });
     }
@@ -280,7 +280,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
         resolve({
           success: false,
           reason: 'TIMEOUT',
-          reasonDetail:
+          message:
             'failed to initialize onReady before timeout, either the datafile or user info was not set before the timeout',
           dataReadyPromise: this.dataReadyPromise,
         });
@@ -405,8 +405,9 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     }
 
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
+
     if (user.id === null) {
-      logger.warn('Unable to activate experiment "%s" because User ID is not set', experimentKey);
+      logger.info('Unable to activate experiment "%s" because User ID is not set', experimentKey);
       return null;
     }
 
@@ -429,8 +430,9 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     }
 
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
+
     if (user.id === null) {
-      logger.warn('Unable to evaluate feature "%s" because User ID is not set.', key);
+      logger.info('Unable to evaluate feature "%s" because User ID is not set.', key);
       return createFailedDecision(key, `Unable to evaluate flag ${key} because User ID is not set.`, user);
     }
 
@@ -459,8 +461,9 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     }
 
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
+
     if (user.id === null) {
-      logger.warn('Unable to evaluate features for keys because User ID is not set');
+      logger.info('Unable to evaluate features for keys because User ID is not set');
       return {};
     }
 
@@ -494,8 +497,9 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     }
 
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
+
     if (user.id === null) {
-      logger.warn('Unable to evaluate all feature decisions because User ID is not set');
+      logger.info('Unable to evaluate all feature decisions because User ID is not set');
       return {};
     }
 
@@ -540,8 +544,9 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     }
 
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
+
     if (user.id === null) {
-      logger.warn('Unable to get variation for experiment "%s" because User ID is not set', experimentKey);
+      logger.info('Unable to get variation for experiment "%s" because User ID is not set', experimentKey);
       return null;
     }
 
@@ -576,7 +581,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
 
     if (user.id === null) {
-      logger.warn('Unable to send tracking event "%s" because User ID is not set', eventKey);
+      logger.info('Unable to send tracking event "%s" because User ID is not set', eventKey);
       return;
     }
 
@@ -651,7 +656,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
    */
   public removeAllForcedDecisions(): boolean {
     if (!this.userContext) {
-      logger.warn('Unable to remove a forced decision because the user context has not been set yet.');
+      logger.warn('Unable to remove all forced decisions because the user context has not been set yet.');
       return false;
     }
 
@@ -687,8 +692,9 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     }
 
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
+
     if (user.id === null) {
-      logger.warn('Unable to determine if feature "%s" is enabled because User ID is not set', feature);
+      logger.info('Unable to determine if feature "%s" is enabled because User ID is not set', feature);
       return false;
     }
 
@@ -744,7 +750,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
 
     const feature = optlyConfig.featuresMap[featureKey];
     if (!feature) {
-      logger.warn(
+      logger.info(
         'Unable to retrieve feature variables for feature "%s" because config features map is not set',
         featureKey
       );
@@ -784,8 +790,9 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     }
 
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
+
     if (user.id === null) {
-      logger.warn('Unable to get feature variable string from feature "%s" because User ID is not set', feature);
+      logger.info('Unable to get feature variable string from feature "%s" because User ID is not set', feature);
       return null;
     }
 
@@ -819,7 +826,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
 
     if (user.id === null) {
-      logger.warn('Unable to get feature variable boolean from feature "%s" because User ID is not set', feature);
+      logger.info('Unable to get feature variable boolean from feature "%s" because User ID is not set', feature);
       return null;
     }
 
@@ -853,7 +860,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
 
     if (user.id === null) {
-      logger.warn('Unable to get feature variable integer from feature "%s" because User ID is not set', feature);
+      logger.info('Unable to get feature variable integer from feature "%s" because User ID is not set', feature);
       return null;
     }
 
@@ -887,7 +894,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
 
     if (user.id === null) {
-      logger.warn('Unable to get feature variable double from feature "%s" because User ID is not set', feature);
+      logger.info('Unable to get feature variable double from feature "%s" because User ID is not set', feature);
       return null;
     }
 
@@ -921,7 +928,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
 
     if (user.id === null) {
-      logger.warn('Unable to get feature variable JSON from feature "%s" because User ID is not set', feature);
+      logger.info('Unable to get feature variable JSON from feature "%s" because User ID is not set', feature);
       return null;
     }
 
@@ -956,7 +963,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
 
     if (user.id === null) {
-      logger.warn(
+      logger.info(
         'Unable to get feature variable from feature "%s" because User ID is not set',
         featureKey,
         variableKey
@@ -991,7 +998,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
 
     if (user.id === null) {
-      logger.warn('Unable to get all feature variables from feature "%s" because User ID is not set', featureKey);
+      logger.info('Unable to get all feature variables from feature "%s" because User ID is not set', featureKey);
       return {};
     }
 
@@ -1014,9 +1021,10 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     const user = this.getUserContextWithOverrides(overrideUserId, overrideAttributes);
 
     if (user.id === null) {
-      logger.warn('Unable to get list of enabled features because User ID is not set');
+      logger.info('Unable to get list of enabled features because User ID is not set');
       return [];
     }
+
     return this._client.getEnabledFeatures(user.id, user.attributes);
   }
 
@@ -1039,7 +1047,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     const user = this.getUserContextWithOverrides(overrideUserId);
 
     if (user.id === null) {
-      logger.warn('Unable to get forced variation for experiment "%s" because User ID is not set', experiment);
+      logger.info('Unable to get forced variation for experiment "%s" because User ID is not set', experiment);
       return null;
     }
 

--- a/src/hooks.spec.tsx
+++ b/src/hooks.spec.tsx
@@ -77,7 +77,7 @@ describe('hooks', () => {
   beforeEach(() => {
     getOnReadyPromise = ({ timeout = 0 }: any): Promise<OnReadyResult> =>
       new Promise(resolve => {
-        setTimeout(function() {
+        setTimeout(function () {
           resolve(
             Object.assign(
               {
@@ -109,13 +109,13 @@ describe('hooks', () => {
       isFeatureEnabled: isFeatureEnabledMock,
       onUserUpdate: jest.fn().mockImplementation(handler => {
         userUpdateCallbacks.push(handler);
-        return () => {};
+        return () => { };
       }),
       notificationCenter: {
         addNotificationListener: jest.fn().mockImplementation((type, handler) => {
           notificationListenerCallbacks.push(handler);
         }),
-        removeNotificationListener: jest.fn().mockImplementation(id => {}),
+        removeNotificationListener: jest.fn().mockImplementation(id => { }),
       },
       user: {
         id: 'testuser',
@@ -126,7 +126,7 @@ describe('hooks', () => {
       getIsUsingSdkKey: () => true,
       onForcedVariationsUpdate: jest.fn().mockImplementation(handler => {
         forcedVariationUpdateCallbacks.push(handler);
-        return () => {};
+        return () => { };
       }),
       getForcedVariations: jest.fn().mockReturnValue({}),
       decide: decideMock,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -139,7 +139,7 @@ function subscribeToInitialization(
       switch (res.reason) {
         // Optimizely client failed to initialize.
         case 'NO_CLIENT':
-          hooksLogger.info(`Client not ready, reason="${res.reasonDetail}"`);
+          hooksLogger.warn(`Client not ready, reason="${res.message}"`);
           onInitStateChange({
             clientReady: false,
             didTimeout: false,
@@ -155,7 +155,7 @@ function subscribeToInitialization(
         // Assume timeout for all other cases.
         // TODO: Other reasons may fall into this case - need to update later to specify 'TIMEOUT' case and general fallback case.
         default:
-          hooksLogger.info(`Client did not become ready before timeout of ${timeout}ms, reason="${res.reasonDetail}"`);
+          hooksLogger.info(`Client did not become ready before timeout of ${timeout}ms, reason="${res.message}"`);
           onInitStateChange({
             clientReady: false,
             didTimeout: true,
@@ -257,7 +257,7 @@ export const useExperiment: UseExperiment = (experimentKey, options = {}, overri
         }));
       });
     }
-    return (): void => {};
+    return (): void => { };
   }, [optimizely.getIsReadyPromiseFulfilled(), options.autoUpdate, optimizely, experimentKey, getCurrentDecision]);
 
   useEffect(
@@ -350,7 +350,7 @@ export const useFeature: UseFeature = (featureKey, options = {}, overrides = {})
         }));
       });
     }
-    return (): void => {};
+    return (): void => { };
   }, [optimizely.getIsReadyPromiseFulfilled(), options.autoUpdate, optimizely, featureKey, getCurrentDecision]);
 
   return [state.isEnabled, state.variables, state.clientReady, state.didTimeout];
@@ -379,11 +379,11 @@ export const useDecision: UseDecision = (flagKey, options = {}, overrides = {}) 
     const decisionState = isClientReady
       ? getCurrentDecision()
       : {
-          decision: createFailedDecision(flagKey, 'Optimizely SDK not configured properly yet.', {
-            id: overrides.overrideUserId || null,
-            attributes: overrideAttrs,
-          }),
-        };
+        decision: createFailedDecision(flagKey, 'Optimizely SDK not configured properly yet.', {
+          id: overrides.overrideUserId || null,
+          attributes: overrideAttrs,
+        }),
+      };
     return {
       ...decisionState,
       clientReady: isClientReady,
@@ -449,9 +449,8 @@ export const useDecision: UseDecision = (flagKey, options = {}, overrides = {}) 
         }));
       });
     }
-    return (): void => {};
+    return (): void => { };
   }, [optimizely.getIsReadyPromiseFulfilled(), options.autoUpdate, optimizely, flagKey, getCurrentDecision]);
 
-  // CHECK: Return clientReady as false & didTimeout as true if ._client is null.
   return [state.decision, state.clientReady, state.didTimeout];
 };

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -431,5 +431,6 @@ export const useDecision: UseDecision = (flagKey, options = {}, overrides = {}) 
     return (): void => {};
   }, [optimizely.getIsReadyPromiseFulfilled(), options.autoUpdate, optimizely, flagKey, getCurrentDecision]);
 
+  // CHECK: Return clientReady as false & didTimeout as true if ._client is null.
   return [state.decision, state.clientReady, state.didTimeout];
 };


### PR DESCRIPTION
# Summary

Handle React SDK fail catching if ._client returns null when creating new ReactClientSDK instance from `createInstance` function.

# Test Plan

Manually tested thoroughly.
All existing unit tests pass.

# Issues
#134 