### PR TITLE
fix: Exported types `ActivateListenerPayload` and `TrackListenerPayload`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Enhancements
 - fixed issue [#49](https://github.com/optimizely/react-sdk/issues/49): Return type of `createInstance` was `OptimizelyReactSDKClient` which is the implementation class. Changed it to the `ReactSDKClient` interface instead ([#148](https://github.com/optimizely/react-sdk/pull/148)).
 
+- fixed issue [#121](https://github.com/optimizely/react-sdk/issues/121):`ActivateListenerPayload` and `TrackListenerPayload` types were exported from optimizely-sdk but was missing in react-sdk export list. ([#150](https://github.com/optimizely/react-sdk/pull/150)).
+
 ## [2.8.0] - January 26, 2022
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Enhancements
 - fixed issue [#49](https://github.com/optimizely/react-sdk/issues/49): Return type of `createInstance` was `OptimizelyReactSDKClient` which is the implementation class. Changed it to the `ReactSDKClient` interface instead ([#148](https://github.com/optimizely/react-sdk/pull/148)).
 
-- fixed issue [#121](https://github.com/optimizely/react-sdk/issues/121):`ActivateListenerPayload` and `TrackListenerPayload` types were exported from optimizely-sdk but was missing in react-sdk export list. ([#150](https://github.com/optimizely/react-sdk/pull/150)).
+- fixed issue [#121](https://github.com/optimizely/react-sdk/issues/121):`ActivateListenerPayload` and `TrackListenerPayload` types were exported from `@optimizely/optimizely-sdk` but were missing from `@optimizely/react-sdk` exports. ([#150](https://github.com/optimizely/react-sdk/pull/150)).
 
 ## [2.8.0] - January 26, 2022
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,8 @@ export { OptimizelyExperiment } from './Experiment';
 export { OptimizelyVariation } from './Variation';
 export { OptimizelyDecision } from './utils';
 
-export {
+export
+ {
   logging,
   errorHandler,
   setLogger,
@@ -30,7 +31,10 @@ export {
   enums,
   eventDispatcher,
   OptimizelyDecideOption,
-} from '@optimizely/optimizely-sdk';
+  ActivateListenerPayload,
+  TrackListenerPayload
+} 
+from '@optimizely/optimizely-sdk';
 
 export { createInstance, ReactSDKClient } from './client';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,8 @@ export
   eventDispatcher,
   OptimizelyDecideOption,
   ActivateListenerPayload,
-  TrackListenerPayload
+  TrackListenerPayload,
+  ListenerPayload
 } 
 from '@optimizely/optimizely-sdk';
 


### PR DESCRIPTION
### Summary
`ActivateListenerPayload` and `TrackListenerPayload` types were exported from `@optimizely/optimizely-sdk` but were missing in `@optimizely/react-sdk` exports.

### Test Plan
Manually tested thoroughly.
All existing unit tests pass.

### Issues
#121 