### PR TITLE
chore: Adding E2E tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       before_script:
         - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
       script:
-        - $HOME/travisci-tools/trigger-script-with-status-update.sh
+        - $HOME/travisci-tools/trigger-script-with-status-update.sh main
       after_success: travis_terminate 0
 
     - stage: 'Publish'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: generic
 os: linux
 
 stages:
-  - 'Lint markdown files'
-  - 'Test'
   - 'Integration tests'
+  - 'Lint markdown files'
+  - 'Test'  
   - 'Publish'
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
       before_script:
         - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
       script:
-        - $HOME/travisci-tools/trigger-script-with-status-update.sh zeeshan/setup-travis
+        - REPO_SLUG=optimizely\/react-sdk-integration-tests $HOME/travisci-tools/trigger-script-with-status-update.sh zeeshan/setup-travis
       after_success: travis_terminate 0
 
     - stage: 'Lint markdown files'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
       before_script:
         - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
       script:
-        - REPO_SLUG=optimizely/react-sdk-integration-tests $HOME/travisci-tools/trigger-script-with-status-update.sh zeeshan/setup-travis
+        - REPO_SLUG="optimizely/react-sdk-integration-tests" $HOME/travisci-tools/trigger-script-with-status-update.sh zeeshan/setup-travis
       after_success: travis_terminate 0
 
     - stage: 'Lint markdown files'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       env:
         SDK=react
         SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
-        REPO_SLUG=optimizely/react-sdk-integration-tests
+        REPO_SLUG=optimizely/react-sdk-e2e-tests
       before_install: skip
       install: skip
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ jobs:
     - stage: 'Integration tests'
       language: minimal
       env:
-        SDK=react
-        SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
+        SDK: react
+        SDK_BRANCH: ${TRAVIS_PULL_REQUEST_BRANCH}
         # Need to provide REPO_SLUG here otherwise it defaults to Fullstack suite repos.
-        REPO_SLUG=optimizely/react-sdk-e2e-tests
+        REPO_SLUG: optimizely/react-sdk-e2e-tests
       before_install: skip
       install: skip
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       env:
         SDK=react
         SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
-        REPO_SLUG=optimizely/react-sdk-integeration-tests
+        REPO_SLUG=optimizely/fullstack-sdk-compatibility-suite
       before_install: skip
       install: skip
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,13 @@ language: generic
 os: linux
 
 stages:
-  - 'Integration tests'
   - 'Lint markdown files'
-  - 'Test'  
+  - 'Test'
+  - 'Integration tests'
   - 'Publish'
 
 jobs:
   include:
-    - stage: 'Integration tests'
-      cache: false
-      language: minimal
-      env:
-        SDK=react
-        SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
-        REPO_SLUG=optimizely/react-sdk-e2e-tests
-      before_install: skip
-      install: skip
-      before_script:
-        - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
-      script:
-        - $HOME/travisci-tools/trigger-script-with-status-update.sh zeeshan/setup-travis
-      after_success: travis_terminate 0
-
     - stage: 'Lint markdown files'
       os: linux
       language: generic
@@ -40,6 +25,21 @@ jobs:
       script: yarn test
       addons:
         srcclr: true
+
+    - stage: 'Integration tests'
+      cache: false
+      language: minimal
+      env:
+        SDK=react
+        SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
+        REPO_SLUG=optimizely/react-sdk-e2e-tests
+      before_install: skip
+      install: skip
+      before_script:
+        - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
+      script:
+        - $HOME/travisci-tools/trigger-script-with-status-update.sh zeeshan/setup-travis
+      after_success: travis_terminate 0
 
     - stage: 'Publish'
       if: type = push AND tag IS present AND tag =~ /^[0-9]+\.[0-9]+\.[0-9]+/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,16 @@ jobs:
     - stage: 'Integration tests'
       cache: false
       language: minimal
+      env:
+        SDK=react
+        SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
+        REPO_SLUG=optimizely/react-sdk-integration-tests
       before_install: skip
       install: skip
       before_script:
         - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
       script:
-        - REPO_SLUG=optimizely\/react-sdk-integration-tests $HOME/travisci-tools/trigger-script-with-status-update.sh zeeshan/setup-travis
+        - $HOME/travisci-tools/trigger-script-with-status-update.sh zeeshan/setup-travis
       after_success: travis_terminate 0
 
     - stage: 'Lint markdown files'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       env:
         SDK=react
         SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
-        REPO_SLUG=optimizely/react-sdk-integration-tests
+        REPO_SLUG=optimizely/react-sdk-integeration-tests
       before_install: skip
       install: skip
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,12 @@ language: generic
 os: linux
 
 stages:
-  - 'Lint markdown files'
   - 'Test'
   - 'Integration tests'
   - 'Publish'
 
 jobs:
   include:
-    - stage: 'Lint markdown files'
-      os: linux
-      language: generic
-      install: gem install awesome_bot
-      before_script: skip
-      script:
-        - find . -type f -name '*.md' -exec awesome_bot {} \;
-
     - stage: 'Test'
       os: linux
       language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       before_script:
         - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
       script:
-        - $HOME/travisci-tools/trigger-script-with-status-update.sh zeeshan/setup-travis
+        - $HOME/travisci-tools/trigger-script-with-status-update.sh
       after_success: travis_terminate 0
 
     - stage: 'Publish'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,22 @@ os: linux
 stages:
   - 'Lint markdown files'
   - 'Test'
+  - 'Integration tests'
   - 'Publish'
 
 jobs:
   include:
+    - stage: 'Integration tests'
+      cache: false
+      language: minimal
+      before_install: skip
+      install: skip
+      before_script:
+        - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
+      script:
+        - REPO_SLUG=optimizely/react-sdk-integration-tests $HOME/travisci-tools/trigger-script-with-status-update.sh zeeshan/setup-travis
+      after_success: travis_terminate 0
+
     - stage: 'Lint markdown files'
       os: linux
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
       before_script:
         - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
       script:
-        - REPO_SLUG="optimizely/react-sdk-integration-tests" $HOME/travisci-tools/trigger-script-with-status-update.sh zeeshan/setup-travis
+        - $HOME/travisci-tools/trigger-script-with-status-update.sh zeeshan/setup-travis
       after_success: travis_terminate 0
 
     - stage: 'Lint markdown files'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       env:
         SDK=react
         SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
-        REPO_SLUG=optimizely/fullstack-sdk-compatibility-suite
+        REPO_SLUG=optimizely/react-sdk-integration-tests
       before_install: skip
       install: skip
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ jobs:
         srcclr: true
 
     - stage: 'Integration tests'
-      cache: false
       language: minimal
       env:
         SDK=react
         SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
+        # Need to provide REPO_SLUG here otherwise it defaults to Fullstack suite repos.
         REPO_SLUG=optimizely/react-sdk-e2e-tests
       before_install: skip
       install: skip


### PR DESCRIPTION
## Summary
React SDK contains unit tests but its not possible to cover many scenarios using those. We have started working on an E2E test suite in a private repo [here](https://github.com/optimizely/react-sdk-e2e-tests). This PR enables this repo to trigger E2E tests on PRs. E2E test suite is not complete yet, so we are not making the check mandatory. Once we have something significant in that repo, we will make this check mandatory.

Since we were working in the travis config file, we cleaned it up a bit and removed the unnecessary markdown lint which has already been removed from other repos.

## Test Plan
Tested the triggering mechanism thoroughly and it appears to be working fine.
