### PR TITLE
fix: Redundant activate calls in useExperiment hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- None yet!
+### Bug fixes
+- Fixed Redundant activate calls in useExperiment hook in a scenario.
 
 ## [2.9.0] - June 15, 2022
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -240,7 +240,7 @@ export const useExperiment: UseExperiment = (experimentKey, options = {}, overri
     //    and we need to wait for the promise and update decision.
     // 2. When client is using datafile only but client is not ready yet which means user
     //    was provided as a promise and we need to subscribe and wait for user to become available.
-    if (optimizely.getIsUsingSdkKey() || !isClientReady) {
+    if ((optimizely.getIsUsingSdkKey() && !optimizely.getIsReadyPromiseFulfilled()) || !isClientReady) {
       subscribeToInitialization(optimizely, finalReadyTimeout, initState => {
         setState({
           ...getCurrentDecision(),


### PR DESCRIPTION
## Summary
In some scenarios, the useExperiment hook was making two activate calls which results in redundant impression events which has a cost impact on the customers. This PR fixes the redundant activate calls.

## Test Plan
- Manually tested thoroughly in many scenarios. 
- All existing tests pass.