### PR TITLE
added useCallback to getCurrentDecision in useDecision hook

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -394,10 +394,12 @@ export const useDecision: UseDecision = (flagKey, options = {}, overrides = {}) 
   }
 
   const overrideAttrs = useCompareAttrsMemoize(overrides.overrideAttributes);
-
-  const getCurrentDecision: () => { decision: OptimizelyDecision } = () => ({
-    decision: optimizely.decide(flagKey, options.decideOptions, overrides.overrideUserId, overrideAttrs),
-  });
+  const getCurrentDecision: () => { decision: OptimizelyDecision } = useCallback(
+    () => ({
+      decision: optimizely.decide(flagKey, options.decideOptions, overrides.overrideUserId, overrideAttrs),
+    }),
+    [optimizely, flagKey, options.decideOptions, overrides.overrideUserId, overrideAttrs]
+  );
 
   const isClientReady = isServerSide || optimizely.isReady();
   const [state, setState] = useState<{ decision: OptimizelyDecision } & InitializationState>(() => {


### PR DESCRIPTION
adding useCallback here fixed a few things:
1. Bug: if you used multiple useDecision hooks with { autoUpdate: true }, the second one would not autoUpdate (you had to fully reload the app to get the decision to update)
2. Before it was redefining getCurrentDecision on every rerender of the useDecision hook, which decreased performance