### PR TITLE
[FSSDK-9494] Update references to old sub modules js-sdk-*

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@optimizely/optimizely-sdk": "5.0.0-beta2",
+    "@optimizely/optimizely-sdk": "^5.0.0-beta5",
     "hoist-non-react-statics": "^3.3.0",
     "prop-types": "^15.6.2",
     "utility-types": "^2.1.0 || ^3.0.0"

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -1,11 +1,11 @@
 /**
- * Copyright 2022, Optimizely
+ * Copyright 2022-2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,9 @@
  */
 import * as React from 'react';
 import { UserAttributes } from '@optimizely/optimizely-sdk';
-import { getLogger } from '@optimizely/js-sdk-logging';
+import { getLogger } from '@optimizely/optimizely-sdk';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { OptimizelyContextProvider } from './Context';
 import { ReactSDKClient } from './client';
 import { areUsersEqual, UserInfo } from './utils';

--- a/src/autoUpdate.ts
+++ b/src/autoUpdate.ts
@@ -1,11 +1,11 @@
 /**
- * Copyright 2020, Optimizely
+ * Copyright 2020, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 import { enums } from '@optimizely/optimizely-sdk';
-import { LoggerFacade } from '@optimizely/js-sdk-logging';
-
 import { ReactSDKClient } from './client';
+import { LoggerFacade } from '@optimizely/optimizely-sdk/dist/modules/logging';
 
 interface AutoUpdate {
   (

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2019, 2022, Optimizely
+ * Copyright 2018-2019, 2022-2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 import { useCallback, useContext, useEffect, useState, useRef } from 'react';
-
 import { UserAttributes, OptimizelyDecideOption } from '@optimizely/optimizely-sdk';
-import { getLogger, LoggerFacade } from '@optimizely/js-sdk-logging';
-
+import { getLogger } from '@optimizely/optimizely-sdk';
+import { LoggerFacade } from '@optimizely/optimizely-sdk/dist/modules/logging';
 import { setupAutoUpdateListeners } from './autoUpdate';
 import { ReactSDKClient, VariableValuesObject, OnReadyResult } from './client';
 import { notifier } from './notifier';

--- a/src/logOnlyEventDispatcher.spec.ts
+++ b/src/logOnlyEventDispatcher.spec.ts
@@ -1,11 +1,27 @@
-jest.mock('@optimizely/js-sdk-logging', () => ({
+/**
+ * Copyright 2023, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+jest.mock('@optimizely/optimizely-sdk', () => ({
   getLogger: jest.fn().mockReturnValue({ debug: jest.fn() }),
 }));
 
 import logOnlyEventDispatcher from './logOnlyEventDispatcher';
-import * as logging from '@optimizely/js-sdk-logging';
+import { getLogger } from '@optimizely/optimizely-sdk';
 
-const logger = logging.getLogger('ReactSDK');
+const logger = getLogger('ReactSDK');
 
 describe('logOnlyEventDispatcher', () => {
   it('logs a message', () => {

--- a/src/logOnlyEventDispatcher.ts
+++ b/src/logOnlyEventDispatcher.ts
@@ -1,11 +1,11 @@
 /**
- * Copyright 2019, Optimizely
+ * Copyright 2019, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,9 +15,9 @@
  */
 
 import * as optimizely from '@optimizely/optimizely-sdk';
-import * as logging from '@optimizely/js-sdk-logging';
+import { getLogger } from '@optimizely/optimizely-sdk';
 
-const logger = logging.getLogger('ReactSDK');
+const logger = getLogger('ReactSDK');
 
 /**
  * logOnlyEventDispatcher only logs a message at the debug level, and does not

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,38 +535,15 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@optimizely/js-sdk-datafile-manager@^0.9.5":
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/@optimizely/js-sdk-datafile-manager/-/js-sdk-datafile-manager-0.9.5.tgz#c1fa25a4bbdabe97929c72895ca2a48e28047a34"
-  integrity sha512-O4ujr1nBBAQBtx8YoKNpzzaEZgsE+aU4dxubT17ePqv/YVUWE+JOY21tSRrqZy/BlbbyzL+ElT8hrGB5ZzVoIQ==
+"@optimizely/optimizely-sdk@^5.0.0-beta5":
+  version "5.0.0-beta5"
+  resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-5.0.0-beta5.tgz#67ac961be3d1269d2774ec758659d42a3e763e38"
+  integrity sha512-xQ1Lv306d9xQoK/vr0o4Wpn53gJNVUeJVi8N90NinDYjtFPsXasdWEFNXNN+qH678VmdpBsPPKLg/5olLoFrKg==
   dependencies:
-    "@optimizely/js-sdk-logging" "^0.3.1"
-    "@optimizely/js-sdk-utils" "^0.4.0"
-    decompress-response "^4.2.1"
-
-"@optimizely/js-sdk-logging@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@optimizely/js-sdk-logging/-/js-sdk-logging-0.3.1.tgz#358b48f4ce2ce22b1969d9e3e929caac1e6e6351"
-  integrity sha512-K71Jf283FP0E4oXehcXTTM3gvgHZHr7FUrIsw//0mdJlotHJT4Nss4hE0CWPbBxO7LJAtwNnO+VIA/YOcO4vHg==
-  dependencies:
-    "@optimizely/js-sdk-utils" "^0.4.0"
-
-"@optimizely/js-sdk-utils@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@optimizely/js-sdk-utils/-/js-sdk-utils-0.4.0.tgz#835b88bc7b5365a5c4a3d073c01c3a55d9f93a8f"
-  integrity sha512-QG2oytnITW+VKTJK+l0RxjaS5VrA6W+AZMzpeg4LCB4Rn4BEKtF+EcW/5S1fBDLAviGq/0TLpkjM3DlFkJ9/Gw==
-  dependencies:
-    uuid "^3.3.2"
-
-"@optimizely/optimizely-sdk@5.0.0-beta2":
-  version "5.0.0-beta2"
-  resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-5.0.0-beta2.tgz#83eb7ea3fb94ad6e75263c1493f219d3cfff0595"
-  integrity sha512-UnA5Nk1ZbmpsJoHt2uizJ+Rb0qx6Jrt2+g9rPguzbkr1HMFDiK1apod8+9NVzB98SroXSA+dHTlBc+OAVp7m4w==
-  dependencies:
-    "@optimizely/js-sdk-datafile-manager" "^0.9.5"
     decompress-response "^4.2.1"
     json-schema "^0.4.0"
     murmurhash "^2.0.1"
+    ua-parser-js "^1.0.35"
     uuid "^8.3.2"
 
 "@rollup/plugin-commonjs@^16.0.0":
@@ -4675,6 +4652,11 @@ typescript@^4.7.4:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
+ua-parser-js@^1.0.35:
+  version "1.0.36"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.36.tgz#a9ab6b9bd3a8efb90bb0816674b412717b7c428c"
+  integrity sha512-znuyCIXzl8ciS3+y3fHJI/2OhQIXbXw9MWC/o3qwyR+RGppjZHrM27CGFSKCJXi2Kctiz537iOu2KnXs1lMQhw==
+
 uglify-js@^3.4.9:
   version "3.16.3"
   resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz"
@@ -4742,11 +4724,6 @@ use@^3.1.0:
   version "3.10.0"
   resolved "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz"
   integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==
-
-uuid@^3.3.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
## Summary
- JS SDK beta5 removes all old sub-modules. This PR updates the React SDK to use that version and beyond

## Test plan
- All existing tests should pass

## Issues
- FSSDK-9494