### PR TITLE
[FSSDK-9494] Remove yarn from npm publish

### DIFF
--- a/.github/workflows/react_release.yml
+++ b/.github/workflows/react_release.yml
@@ -22,4 +22,4 @@ jobs:
     - name: Test, build, then publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_REACT_SDK_TO_NPM }}
-      run: yarn npm publish
+      run: npm publish


### PR DESCRIPTION
## Summary
- https://yarnpkg.com/cli/npm/publish didn't work


## Test plan
- Existing tests should succeed

## Issues
- FSSDK-9494