### PR TITLE
[FSSDK-9494] Fix the name of the token used to publish

### DIFF
--- a/.github/workflows/react_release.yml
+++ b/.github/workflows/react_release.yml
@@ -21,5 +21,5 @@ jobs:
       run: yarn install
     - name: Test, build, then publish
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_REACT_SDK_TO_NPM }}
+        NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_REACT_TO_NPM_FROM_GITHUB }}
       run: npm publish


### PR DESCRIPTION
## Summary
- Correction to the name of the repository secret used to publish to npm 
I can't believe I didn't see this 🤦Thanks GPT for having me check it.

## Test plan
- All existing tests should pass.

## Issues
- FSSDK-9494