### PR TITLE
[FSSDK-9494] Tag release correctly during publishing

### DIFF
--- a/.github/workflows/react_release.yml
+++ b/.github/workflows/react_release.yml
@@ -3,9 +3,6 @@ name: Publish React SDK to NPM
 on:
   release:
     types: [ published ]
-  push:
-    branches:
-      - mike/tag-correctly-during-publish
 
 jobs:
   publish:
@@ -28,7 +25,7 @@ jobs:
       run: yarn install
 
     - id: npm-tag
-      name: Determine NPM Tag
+      name: Determine NPM tag
       run: |
         version=$(jq -r '.version' package.json)
         if [[ "$version" == *"-beta"* ]]; then
@@ -44,4 +41,4 @@ jobs:
     - name: Test, build, then publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_REACT_TO_NPM_FROM_GITHUB }}
-      run: npm publish --tag ${{ steps.npm-tag.outputs['npm-tag'] }} --dry-run
+      run: npm publish --tag ${{ steps.npm-tag.outputs['npm-tag'] }}

--- a/.github/workflows/react_release.yml
+++ b/.github/workflows/react_release.yml
@@ -3,6 +3,9 @@ name: Publish React SDK to NPM
 on:
   release:
     types: [ published ]
+  push:
+    branches:
+      - mike/tag-correctly-during-publish
 
 jobs:
   publish:
@@ -11,15 +14,34 @@ jobs:
     steps:
     - name: Checkout branch
       uses: actions/checkout@v4
+
     - name: Set up Node
       uses: actions/setup-node@v3
       with:
         node-version: 18
         registry-url: "https://registry.npmjs.org/"
         always-auth: "true"
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_REACT_TO_NPM_FROM_GITHUB }}
+
     - name: Install dependencies
       run: yarn install
+
+    - id: npm-tag
+      name: Determine NPM Tag
+      run: |
+        version=$(jq -r '.version' package.json)
+        if [[ "$version" == *"-beta"* ]]; then
+          echo "npm-tag=beta" >> "$GITHUB_OUTPUT"
+        elif [[ "$version" == *"-alpha"* ]]; then
+          echo "npm-tag=alpha" >> "$GITHUB_OUTPUT"
+        elif [[ "$version" == *"-rc"* ]]; then
+          echo "npm-tag=rc" >> "$GITHUB_OUTPUT"
+        else
+          echo "npm-tag=latest" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Test, build, then publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_REACT_TO_NPM_FROM_GITHUB }}
-      run: npm publish
+      run: npm publish --tag ${{ steps.npm-tag.outputs['npm-tag'] }} --dry-run


### PR DESCRIPTION
## Summary
- Update the release workflow to read the package.json and tag the release in NPM correctly:
  - `beta`
  - `alpha`
  - `rc`
  - else `latest`

## Test plan
- I've tested this functionality in this (--dry-run](https://github.com/optimizely/react-sdk/actions/runs/6316523677/job/17151333471)
- Existing code tests should continue to pass.

## Issues
- FSSDK-9494