### PR TITLE
[FSSDK-9654] fix: Default to VUID without user(id) as Provider prop

### DIFF
--- a/src/Experiment.spec.tsx
+++ b/src/Experiment.spec.tsx
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /// <reference types="jest" />
+
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -43,10 +45,11 @@ describe('<OptimizelyExperiment>', () => {
     optimizelyMock = ({
       onReady: jest.fn().mockImplementation(() => onReadyPromise),
       activate: jest.fn().mockImplementation(() => variationKey),
-      onUserUpdate: jest.fn().mockImplementation(() => () => { }),
+      onUserUpdate: jest.fn().mockImplementation(() => () => {}),
+      getVuid: jest.fn().mockImplementation(() => 'vuid_95bf72cebc774dfd8e8e580a5a1'),
       notificationCenter: {
-        addNotificationListener: jest.fn().mockImplementation(() => { }),
-        removeNotificationListener: jest.fn().mockImplementation(() => { }),
+        addNotificationListener: jest.fn().mockImplementation(() => {}),
+        removeNotificationListener: jest.fn().mockImplementation(() => {}),
       },
       user: {
         id: 'testuser',
@@ -55,7 +58,7 @@ describe('<OptimizelyExperiment>', () => {
       isReady: jest.fn().mockImplementation(() => isReady),
       getIsReadyPromiseFulfilled: () => true,
       getIsUsingSdkKey: () => true,
-      onForcedVariationsUpdate: jest.fn().mockReturnValue(() => { }),
+      onForcedVariationsUpdate: jest.fn().mockReturnValue(() => {}),
     } as unknown) as ReactSDKClient;
   });
 
@@ -405,7 +408,9 @@ describe('<OptimizelyExperiment>', () => {
       await optimizelyMock.onReady();
 
       expect(optimizelyMock.activate).toHaveBeenCalledWith('experiment1', undefined, undefined);
-      await waitFor(() => expect(screen.getByTestId('variation-key')).toHaveTextContent('matchingVariation|true|false'));
+      await waitFor(() =>
+        expect(screen.getByTestId('variation-key')).toHaveTextContent('matchingVariation|true|false')
+      );
     });
 
     describe('when the onReady() promise return { success: false }', () => {

--- a/src/Feature.spec.tsx
+++ b/src/Feature.spec.tsx
@@ -1,11 +1,11 @@
 /**
- * Copyright 2018-2019, Optimizely
+ * Copyright 2018-2019, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/// <reference types="jest" />
+
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -45,6 +48,7 @@ describe('<OptimizelyFeature>', () => {
       getFeatureVariables: jest.fn().mockImplementation(() => featureVariables),
       isFeatureEnabled: jest.fn().mockImplementation(() => isEnabledMock),
       onUserUpdate: jest.fn().mockImplementation(handler => () => {}),
+      getVuid: jest.fn().mockImplementation(() => 'vuid_95bf72cebc774dfd8e8e580a5a1'),
       notificationCenter: {
         addNotificationListener: jest.fn().mockImplementation((type, handler) => {}),
         removeNotificationListener: jest.fn().mockImplementation(id => {}),

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -45,7 +45,11 @@ export class OptimizelyProvider extends React.Component<OptimizelyProviderProps,
     super(props);
   }
 
-  async componentDidMount() {
+  componentDidMount(): void {
+    this.setUserInOptimizely();
+  }
+
+  async setUserInOptimizely(): Promise<void> {
     const { optimizely, userId, userAttributes, user } = this.props;
 
     if (!optimizely) {

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -57,7 +57,6 @@ export class OptimizelyProvider extends React.Component<OptimizelyProviderProps,
       return;
     }
 
-    //await optimizely.onReady(); // causes problems with hooks
     let finalUser: UserInfo | null = null;
 
     if (user) {
@@ -84,9 +83,10 @@ export class OptimizelyProvider extends React.Component<OptimizelyProviderProps,
 
     if (finalUser) {
       try {
+        await optimizely.onReady();
         await optimizely.setUser(finalUser);
       } catch {
-        logger.error('Unable to set user. Prop optimizely object does not contain the setUser function.');
+        logger.error('Error while trying to set user.');
       }
     }
   }

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -37,7 +37,7 @@ interface OptimizelyProviderProps {
 
 interface OptimizelyProviderState {
   userId: string;
-  attributes: { [key: string]: string; } | undefined;
+  attributes: { [key: string]: string } | undefined;
 }
 
 export class OptimizelyProvider extends React.Component<OptimizelyProviderProps, OptimizelyProviderState> {

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -77,26 +77,6 @@ export class OptimizelyProvider extends React.Component<OptimizelyProviderProps,
       };
       // deprecation warning
       logger.warn('Passing userId and userAttributes as props is deprecated, please switch to using `user` prop');
-    } else {
-      const localStorageVuid = localStorage.getItem('optimizely-vuid');
-
-      if (localStorageVuid) {
-        finalUser = {
-          id: localStorageVuid,
-          attributes: {},
-        };
-      } else {
-        try {
-          await optimizely.onReady();
-
-          finalUser = {
-            id: optimizely.getVuid() || null,
-            attributes: {},
-          };
-        } catch {
-          logger.error('Unable to set user. The Optimizely SDK client is not ready.');
-        }
-      }
     }
 
     if (finalUser) {

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -82,12 +82,16 @@ export class OptimizelyProvider extends React.Component<OptimizelyProviderProps,
           attributes: {},
         };
       } else {
-        await optimizely.onReady();
+        try {
+          await optimizely.onReady();
 
-        finalUser = {
-          id: optimizely.getVuid() || null,
-          attributes: {},
-        };
+          finalUser = {
+            id: optimizely.getVuid() || null,
+            attributes: {},
+          };
+        } catch {
+          logger.error('Unable to set user. The Optimizely SDK client is not ready.');
+        }
       }
     }
 

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -57,7 +57,7 @@ export class OptimizelyProvider extends React.Component<OptimizelyProviderProps,
       return;
     }
 
-    await optimizely.onReady();
+    //await optimizely.onReady(); // causes problems with hooks
     let finalUser: UserInfo | null = null;
 
     if (user) {

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -45,8 +45,8 @@ export class OptimizelyProvider extends React.Component<OptimizelyProviderProps,
     super(props);
   }
 
-  async componentDidMount(): Promise<void> {
-    await this.setUserInOptimizely();
+  componentDidMount(): void {
+    this.setUserInOptimizely();
   }
 
   async setUserInOptimizely(): Promise<void> {

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -1665,7 +1665,7 @@ describe('ReactSDKClient', () => {
       instance.getCurrentUserContext();
 
       expect(logger.warn).toHaveBeenCalledTimes(1);
-      expect(logger.warn).toBeCalledWith('Unable to get user context. Optimizely client not initialized or ready.');
+      expect(logger.warn).toBeCalledWith('Unable to get user context. Optimizely client not initialized.');
     });
 
     it('should log a warning and return null if setUser is not called first', () => {

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -1662,14 +1662,14 @@ describe('ReactSDKClient', () => {
       // @ts-ignore
       instance._client = null;
 
-      instance.getCurrentUserContext();
+      instance.getUserContext();
 
       expect(logger.warn).toHaveBeenCalledTimes(1);
       expect(logger.warn).toBeCalledWith('Unable to get user context. Optimizely client not initialized.');
     });
 
     it('should log a warning and return null if setUser is not called first', () => {
-      instance.getCurrentUserContext();
+      instance.getUserContext();
 
       expect(logger.warn).toHaveBeenCalledTimes(1);
       expect(logger.warn).toBeCalledWith('Unable to get user context. User context not set.');
@@ -1683,7 +1683,7 @@ describe('ReactSDKClient', () => {
         },
       });
 
-      const currentUserContext = instance.getCurrentUserContext();
+      const currentUserContext = instance.getUserContext();
 
       expect(logger.warn).toHaveBeenCalledTimes(0);
       expect(currentUserContext).not.toBeNull();

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -18,10 +18,10 @@ jest.mock('@optimizely/optimizely-sdk');
 jest.mock('./logger', () => {
   return {
     logger: {
-      warn: jest.fn(() => () => { }),
-      info: jest.fn(() => () => { }),
-      error: jest.fn(() => () => { }),
-      debug: jest.fn(() => () => { }),
+      warn: jest.fn(() => () => {}),
+      info: jest.fn(() => () => {}),
+      error: jest.fn(() => () => {}),
+      debug: jest.fn(() => () => {}),
     },
   };
 });
@@ -1665,15 +1665,14 @@ describe('ReactSDKClient', () => {
       instance.getCurrentUserContext();
 
       expect(logger.warn).toHaveBeenCalledTimes(1);
-      expect(logger.warn).toBeCalledWith("Unable to get user context. Optimizely client not initialized or ready.");
+      expect(logger.warn).toBeCalledWith('Unable to get user context. Optimizely client not initialized or ready.');
     });
-
 
     it('should log a warning and return null if setUser is not called first', () => {
       instance.getCurrentUserContext();
 
       expect(logger.warn).toHaveBeenCalledTimes(1);
-      expect(logger.warn).toBeCalledWith("Unable to get user context. User context not set.");
+      expect(logger.warn).toBeCalledWith('Unable to get user context. User context not set.');
     });
 
     it('should return a userContext if setUser is called', () => {

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 jest.mock('@optimizely/optimizely-sdk');
 jest.mock('./logger', () => {
   return {
@@ -1236,10 +1237,6 @@ describe('ReactSDKClient', () => {
       const result = await instance.fetchQualifiedSegments();
 
       expect(result).toEqual(false);
-      expect(logger.warn).toHaveBeenCalledTimes(1);
-      expect(logger.warn).toBeCalledWith(
-        'Unable to fetch qualified segments for user because Optimizely client failed to initialize.'
-      );
     });
 
     it('should return false if fetch fails', async () => {
@@ -1665,18 +1662,18 @@ describe('ReactSDKClient', () => {
       // @ts-ignore
       instance._client = null;
 
-      instance.getUserContext();
+      instance.getCurrentUserContext();
 
       expect(logger.warn).toHaveBeenCalledTimes(1);
-      expect(logger.warn).toBeCalledWith("Unable to get user context because Optimizely client failed to initialize.");
+      expect(logger.warn).toBeCalledWith("Unable to get user context. Optimizely client not initialized or ready.");
     });
 
 
     it('should log a warning and return null if setUser is not called first', () => {
-      instance.getUserContext();
+      instance.getCurrentUserContext();
 
       expect(logger.warn).toHaveBeenCalledTimes(1);
-      expect(logger.warn).toBeCalledWith("Unable to get user context because user was not set.");
+      expect(logger.warn).toBeCalledWith("Unable to get user context. User context not set.");
     });
 
     it('should return a userContext if setUser is called', () => {
@@ -1687,7 +1684,7 @@ describe('ReactSDKClient', () => {
         },
       });
 
-      const currentUserContext = instance.getUserContext();
+      const currentUserContext = instance.getCurrentUserContext();
 
       expect(logger.warn).toHaveBeenCalledTimes(0);
       expect(currentUserContext).not.toBeNull();

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,7 +18,6 @@ import * as optimizely from '@optimizely/optimizely-sdk';
 import { OptimizelyDecision, UserInfo, createFailedDecision, areUsersEqual } from './utils';
 import { notifier } from './notifier';
 import { logger } from './logger';
-import { FeatureVariableValue } from '@optimizely/optimizely-sdk';
 
 export type VariableValuesObject = {
   [key: string]: any;
@@ -118,7 +117,7 @@ export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserConte
     variableKey: string,
     overrideUserId: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): FeatureVariableValue;
+  ): unknown;
 
   getAllFeatureVariables(
     featureKey: string,
@@ -955,7 +954,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     variableKey: string,
     overrideUserId: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): FeatureVariableValue {
+  ): unknown {
     if (!this._client) {
       logger.warn(
         'Unable to get feature variable from feature "%s" because Optimizely client failed to initialize.',

--- a/src/client.ts
+++ b/src/client.ts
@@ -314,6 +314,16 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
   }
 
   public getCurrentUserContext(): optimizely.OptimizelyUserContext | null {
+    if (!this._client) {
+      logger.warn('Unable to get user context. Optimizely client not initialized.');
+      return null;
+    }
+
+    if (!this.userContext) {
+      logger.warn('Unable to get user context. User context not set.');
+      return null;
+    }
+
     return this.userContext;
   }
 
@@ -351,8 +361,8 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     this.setCurrentUserContext(userInfo);
 
     this.user = {
-      id: this.userContext?.getUserId() || DefaultUser.id,
-      attributes: this.userContext?.getAttributes() || DefaultUser.attributes,
+      id: userInfo.id || DefaultUser.id,
+      attributes: userInfo.attributes || DefaultUser.attributes,
     };
 
     if (this.getIsReadyPromiseFulfilled()) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -181,7 +181,7 @@ export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserConte
 
   fetchQualifiedSegments(options?: optimizely.OptimizelySegmentOption[]): Promise<boolean>;
 
-  getCurrentUserContext(): optimizely.OptimizelyUserContext | null;
+  getUserContext(): optimizely.OptimizelyUserContext | null;
 
   setCurrentUserContext(userInfo: UserInfo): void;
 
@@ -309,7 +309,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     });
   }
 
-  public getCurrentUserContext(): optimizely.OptimizelyUserContext | null {
+  public getUserContext(): optimizely.OptimizelyUserContext | null {
     if (!this._client) {
       logger.warn('Unable to get user context. Optimizely client not initialized.');
       return null;

--- a/src/client.ts
+++ b/src/client.ts
@@ -53,7 +53,7 @@ export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserConte
   user: UserInfo;
 
   onReady(opts?: { timeout?: number; }): Promise<any>;
-  setUser(userInfo: UserInfo): Promise<void>;
+  setUser(userInfo: UserInfo): void;
   onUserUpdate(handler: OnUserUpdateHandler): DisposeFn;
   isReady(): boolean;
   getIsReadyPromiseFulfilled(): boolean;
@@ -383,7 +383,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     return await this.userContext.fetchQualifiedSegments(options);
   }
 
-  public async setUser(userInfo: UserInfo): Promise<void> {
+  public setUser(userInfo: UserInfo): void {
     this.isUserReady = true;
 
     this.user = { ...default_user };
@@ -396,7 +396,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     this.setCurrentUserContext(userInfo);
 
     if (this.getIsReadyPromiseFulfilled()) {
-      await this.fetchQualifiedSegments();
+      this.fetchQualifiedSegments();
     }
 
     if (!this.isUserPromiseResolved) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -271,10 +271,6 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     return this.isReadyPromiseFulfilled;
   }
 
-  public isReady(): boolean {
-    return this.isClientReady;
-  }
-
   public getIsUsingSdkKey(): boolean {
     return this.isUsingSdkKey;
   }
@@ -398,6 +394,10 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
         this.onForcedVariationsUpdateHandlers.splice(ind, 1);
       }
     };
+  }
+
+  public isReady(): boolean {
+    return this.isClientReady;
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -183,10 +183,6 @@ export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserConte
 
   getUserContext(): optimizely.OptimizelyUserContext | null;
 
-  setCurrentUserContext(userInfo: UserInfo): void;
-
-  makeUserContextInstance(userInfo: UserInfo): optimizely.OptimizelyUserContext | null;
-
   getVuid(): string | undefined;
 }
 
@@ -323,7 +319,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     return this.userContext;
   }
 
-  public setCurrentUserContext(userInfo: UserInfo): void {
+  private setCurrentUserContext(userInfo: UserInfo): void {
     if (!this._client) {
       logger.warn(`Unable to set user context for user ID ${userInfo.id}. Optimizely client not initialized.`);
       return;
@@ -334,7 +330,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     }
   }
 
-  public makeUserContextInstance(userInfo: UserInfo): optimizely.OptimizelyUserContext | null {
+  private makeUserContextInstance(userInfo: UserInfo): optimizely.OptimizelyUserContext | null {
     if (!this._client || !this.isReady()) {
       logger.warn(
         `Unable to create user context for ${userInfo.id}. Optimizely client failed to initialize or not ready.`

--- a/src/client.ts
+++ b/src/client.ts
@@ -53,7 +53,7 @@ export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserConte
   user: UserInfo;
 
   onReady(opts?: { timeout?: number }): Promise<any>;
-  setUser(userInfo: UserInfo): void;
+  setUser(userInfo: UserInfo): Promise<void>;
   onUserUpdate(handler: OnUserUpdateHandler): DisposeFn;
   isReady(): boolean;
   getIsReadyPromiseFulfilled(): boolean;
@@ -159,14 +159,14 @@ export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserConte
     options?: optimizely.OptimizelyDecideOption[],
     overrideUserId?: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): { [key: string]: OptimizelyDecision };
+  ): { [key: string]: OptimizelyDecision; };
 
   decideForKeys(
     keys: string[],
     options?: optimizely.OptimizelyDecideOption[],
     overrideUserId?: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): { [key: string]: OptimizelyDecision };
+  ): { [key: string]: OptimizelyDecision; };
 
   setForcedDecision(
     decisionContext: optimizely.OptimizelyDecisionContext,
@@ -232,12 +232,9 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     this.isUsingSdkKey = !!configWithClientInfo.sdkKey;
 
     if (this._client) {
-      this._client.onReady().then(() => {
-        this.isClientReady = true;
-      });
-
       this.dataReadyPromise = this._client.onReady().then((clientResult: { success: boolean }) => {
         this.isReadyPromiseFulfilled = true;
+        this.isClientReady = true;
 
         return {
           success: true,
@@ -338,7 +335,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     }
 
     if (!this.userContext || (this.userContext && !areUsersEqual(userInfo, this.user))) {
-      this.userContext = this._client.createUserContext(userInfo.id ?? undefined, userInfo.attributes);
+      this.userContext = this._client.createUserContext(userInfo.id || undefined, userInfo.attributes);
     }
   }
 
@@ -361,11 +358,20 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     return await this.userContext.fetchQualifiedSegments(options);
   }
 
-  public setUser(userInfo: UserInfo): void {
+  public async setUser(userInfo: UserInfo): Promise<void> {
+    //reset user info
+    this.user = { ...DefaultUser };
+
+    this.user.id = userInfo.id;
+
     this.setCurrentUserContext(userInfo);
 
+    if (userInfo.attributes) {
+      this.user.attributes = userInfo.attributes;
+    }
+
     if (this.getIsReadyPromiseFulfilled()) {
-      this.fetchQualifiedSegments();
+      await this.fetchQualifiedSegments();
     }
 
     this.onUserUpdateHandlers.forEach(handler => handler(this.user));
@@ -467,7 +473,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     options: optimizely.OptimizelyDecideOption[] = [],
     overrideUserId?: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): { [key: string]: OptimizelyDecision } {
+  ): { [key: string]: OptimizelyDecision; } {
     if (!this._client) {
       logger.warn('Unable to evaluate features for keys because Optimizely client failed to initialize.');
       return {};
@@ -483,7 +489,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     const optlyUserContext = this.makeUserContextInstance(user);
     if (optlyUserContext) {
       return Object.entries(optlyUserContext.decideForKeys(keys, options)).reduce(
-        (decisions: { [key: string]: OptimizelyDecision }, [key, decision]) => {
+        (decisions: { [key: string]: OptimizelyDecision; }, [key, decision]) => {
           decisions[key] = {
             ...decision,
             userContext: {
@@ -503,7 +509,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     options: optimizely.OptimizelyDecideOption[] = [],
     overrideUserId?: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): { [key: string]: OptimizelyDecision } {
+  ): { [key: string]: OptimizelyDecision; } {
     if (!this._client) {
       logger.warn('Unable to evaluate all feature decisions because Optimizely client is not initialized.');
       return {};
@@ -519,7 +525,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     const optlyUserContext = this.makeUserContextInstance(user);
     if (optlyUserContext) {
       return Object.entries(optlyUserContext.decideAll(options)).reduce(
-        (decisions: { [key: string]: OptimizelyDecision }, [key, decision]) => {
+        (decisions: { [key: string]: OptimizelyDecision; }, [key, decision]) => {
           decisions[key] = {
             ...decision,
             userContext: {
@@ -999,7 +1005,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     featureKey: string,
     overrideUserId: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): { [variableKey: string]: unknown } | null {
+  ): { [variableKey: string]: unknown; } | null {
     if (!this._client) {
       logger.warn(
         'Unable to get all feature variables from feature "%s" because Optimizely client failed to initialize.',
@@ -1128,7 +1134,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
    * Cleanup method for killing an running timers and flushing eventQueue
    * @returns {Promise<{ success: boolean; reason?: string }>}
    */
-  public close(): Promise<{ success: boolean; reason?: string }> {
+  public close(): Promise<{ success: boolean; reason?: string; }> {
     if (!this._client) {
       /**
        * Note:
@@ -1137,7 +1143,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
        * - If we resolve as "false", then the cleanup for timers and the event queue will never trigger.
        * - Not triggering cleanup may lead to memory leaks and other inefficiencies.
        */
-      return new Promise<{ success: boolean; reason: string }>((resolve, reject) =>
+      return new Promise<{ success: boolean; reason: string; }>((resolve, reject) =>
         resolve({
           success: true,
           reason: 'Optimizely client is not initialized.',

--- a/src/client.ts
+++ b/src/client.ts
@@ -256,6 +256,17 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     }
   }
 
+  protected getUserWithOverrides(overrideUserId?: string, overrideAttributes?: optimizely.UserAttributes): UserInfo {
+    const id: string | null = overrideUserId === undefined ? this.user.id : overrideUserId;
+    const attributes: optimizely.UserAttributes | undefined =
+      overrideAttributes === undefined ? this.user.attributes : overrideAttributes;
+
+    return {
+      id,
+      attributes,
+    };
+  }
+
   public getIsReadyPromiseFulfilled(): boolean {
     return this.isReadyPromiseFulfilled;
   }
@@ -300,17 +311,6 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
       }
       return res;
     });
-  }
-
-  protected getUserWithOverrides(overrideUserId?: string, overrideAttributes?: optimizely.UserAttributes): UserInfo {
-    const id: string | null = overrideUserId === undefined ? this.user.id : overrideUserId;
-    const attributes: optimizely.UserAttributes | undefined =
-      overrideAttributes === undefined ? this.user.attributes : overrideAttributes;
-
-    return {
-      id,
-      attributes,
-    };
   }
 
   public getCurrentUserContext(): optimizely.OptimizelyUserContext | null {

--- a/src/client.ts
+++ b/src/client.ts
@@ -337,16 +337,12 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
 
   public getCurrentUserContext(): optimizely.OptimizelyUserContext | null {
     if (!this._client) {
-      logger.warn(
-        'Unable to get user context because Optimizely client failed to initialize.'
-      );
+      logger.warn('Unable to get user context. Optimizely client not initialized.');
       return null;
     }
 
-    if (!this.userContext) {
-      logger.warn(
-        'Unable to get user context because user was not set.'
-      );
+    if (!this.userContext || !this.isUserReady) {
+      logger.warn('Unable to get user context. User was not set nor ready.');
       return null;
     }
 
@@ -355,14 +351,9 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
 
   public setCurrentUserContext(userInfo: UserInfo): void {
     if (!this._client) {
-      logger.warn(
-        'Unable to get user context for user id "%s" because Optimizely client failed to initialize.',
-        userInfo.id
-      );
+      logger.warn(`Unable to set user context for user ID ${userInfo.id}. Optimizely client not initialized.`);
       return;
     }
-
-    let userContext: optimizely.OptimizelyUserContext | null = null;
 
     if (!this.userContext || (this.userContext && !areUsersEqual(userInfo, this.user))) {
       this.userContext = this._client.createUserContext(userInfo.id ?? undefined, userInfo.attributes);

--- a/src/client.ts
+++ b/src/client.ts
@@ -181,7 +181,11 @@ export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserConte
 
   fetchQualifiedSegments(options?: optimizely.OptimizelySegmentOption[]): Promise<boolean>;
 
-  getUserContext(): optimizely.OptimizelyUserContext | null;
+  getCurrentUserContext(): optimizely.OptimizelyUserContext | null;
+
+  setCurrentUserContext(userInfo: UserInfo): void;
+
+  makeUserContextInstance(userInfo: UserInfo): optimizely.OptimizelyUserContext | null;
 
   getVuid(): string | undefined;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -280,8 +280,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
         resolve({
           success: false,
           reason: 'TIMEOUT',
-          message:
-            'failed to initialize onReady before timeout, either the datafile or user info was not set before the timeout',
+          message: 'Failed to initialize onReady before timeout, data was not set before the timeout period',
           dataReadyPromise: this.dataReadyPromise,
         });
       }, timeout) as any;

--- a/src/client.ts
+++ b/src/client.ts
@@ -159,14 +159,14 @@ export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserConte
     options?: optimizely.OptimizelyDecideOption[],
     overrideUserId?: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): { [key: string]: OptimizelyDecision; };
+  ): { [key: string]: OptimizelyDecision };
 
   decideForKeys(
     keys: string[],
     options?: optimizely.OptimizelyDecideOption[],
     overrideUserId?: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): { [key: string]: OptimizelyDecision; };
+  ): { [key: string]: OptimizelyDecision };
 
   setForcedDecision(
     decisionContext: optimizely.OptimizelyDecisionContext,
@@ -473,7 +473,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     options: optimizely.OptimizelyDecideOption[] = [],
     overrideUserId?: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): { [key: string]: OptimizelyDecision; } {
+  ): { [key: string]: OptimizelyDecision } {
     if (!this._client) {
       logger.warn('Unable to evaluate features for keys because Optimizely client failed to initialize.');
       return {};
@@ -489,7 +489,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     const optlyUserContext = this.makeUserContextInstance(user);
     if (optlyUserContext) {
       return Object.entries(optlyUserContext.decideForKeys(keys, options)).reduce(
-        (decisions: { [key: string]: OptimizelyDecision; }, [key, decision]) => {
+        (decisions: { [key: string]: OptimizelyDecision }, [key, decision]) => {
           decisions[key] = {
             ...decision,
             userContext: {
@@ -509,7 +509,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     options: optimizely.OptimizelyDecideOption[] = [],
     overrideUserId?: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): { [key: string]: OptimizelyDecision; } {
+  ): { [key: string]: OptimizelyDecision } {
     if (!this._client) {
       logger.warn('Unable to evaluate all feature decisions because Optimizely client is not initialized.');
       return {};
@@ -525,7 +525,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     const optlyUserContext = this.makeUserContextInstance(user);
     if (optlyUserContext) {
       return Object.entries(optlyUserContext.decideAll(options)).reduce(
-        (decisions: { [key: string]: OptimizelyDecision; }, [key, decision]) => {
+        (decisions: { [key: string]: OptimizelyDecision }, [key, decision]) => {
           decisions[key] = {
             ...decision,
             userContext: {
@@ -1005,7 +1005,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     featureKey: string,
     overrideUserId: string,
     overrideAttributes?: optimizely.UserAttributes
-  ): { [variableKey: string]: unknown; } | null {
+  ): { [variableKey: string]: unknown } | null {
     if (!this._client) {
       logger.warn(
         'Unable to get all feature variables from feature "%s" because Optimizely client failed to initialize.',
@@ -1134,7 +1134,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
    * Cleanup method for killing an running timers and flushing eventQueue
    * @returns {Promise<{ success: boolean; reason?: string }>}
    */
-  public close(): Promise<{ success: boolean; reason?: string; }> {
+  public close(): Promise<{ success: boolean; reason?: string }> {
     if (!this._client) {
       /**
        * Note:
@@ -1143,7 +1143,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
        * - If we resolve as "false", then the cleanup for timers and the event queue will never trigger.
        * - Not triggering cleanup may lead to memory leaks and other inefficiencies.
        */
-      return new Promise<{ success: boolean; reason: string; }>((resolve, reject) =>
+      return new Promise<{ success: boolean; reason: string }>((resolve, reject) =>
         resolve({
           success: true,
           reason: 'Optimizely client is not initialized.',

--- a/src/client.ts
+++ b/src/client.ts
@@ -348,6 +348,26 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     return this.userContext;
   }
 
+  public getCurrentUserContext(): optimizely.OptimizelyUserContext | null {
+    return this.userContext;
+  }
+
+  public setCurrentUserContext(userInfo: UserInfo): void {
+    if (!this._client) {
+      logger.warn(
+        'Unable to get user context for user id "%s" because Optimizely client failed to initialize.',
+        userInfo.id
+      );
+      return;
+    }
+
+    let userContext: optimizely.OptimizelyUserContext | null = null;
+
+    if (!this.userContext || (this.userContext && !areUsersEqual(userInfo, this.user))) {
+      this.userContext = this._client.createUserContext(userInfo.id ?? undefined, userInfo.attributes);
+    }
+  }
+
   public getUserContextInstance(userInfo: UserInfo): optimizely.OptimizelyUserContext | null {
     if (!this._client) {
       logger.warn(
@@ -357,27 +377,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
       return null;
     }
 
-    let userContext: optimizely.OptimizelyUserContext | null = null;
-
-    if (this.userContext) {
-      if (areUsersEqual(userInfo, this.user)) {
-        return this.userContext;
-      }
-
-      if (userInfo.id) {
-        userContext = this._client.createUserContext(userInfo.id, userInfo.attributes);
-        return userContext;
-      }
-
-      return null;
-    }
-
-    if (userInfo.id) {
-      this.userContext = this._client.createUserContext(userInfo.id, userInfo.attributes);
-      return this.userContext;
-    }
-
-    return null;
+    return this._client.createUserContext(userInfo.id || undefined, userInfo.attributes);
   }
 
   public async fetchQualifiedSegments(options?: optimizely.OptimizelySegmentOption[]): Promise<boolean> {

--- a/src/hooks.spec.tsx
+++ b/src/hooks.spec.tsx
@@ -1,11 +1,11 @@
 /**
- * Copyright 2022, Optimizely
+ * Copyright 2022, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/// <reference types="jest" />
+
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -111,6 +114,7 @@ describe('hooks', () => {
       onReady: jest.fn().mockImplementation(config => getOnReadyPromise(config || {})),
       getFeatureVariables: jest.fn().mockImplementation(() => featureVariables),
       isFeatureEnabled: isFeatureEnabledMock,
+      getVuid: jest.fn().mockReturnValue('vuid_95bf72cebc774dfd8e8e580a5a1'),
       onUserUpdate: jest.fn().mockImplementation(handler => {
         userUpdateCallbacks.push(handler);
         return () => {};

--- a/src/hooks.spec.tsx
+++ b/src/hooks.spec.tsx
@@ -81,6 +81,8 @@ describe('hooks', () => {
   let decideMock: jest.Mock<OptimizelyDecision>;
   let setForcedDecisionMock: jest.Mock<void>;
 
+  const REJECTION_REASON = 'A rejection reason you should never see in the test runner';
+
   beforeEach(() => {
     getOnReadyPromise = ({ timeout = 0 }: any): Promise<OnReadyResult> =>
       new Promise(resolve => {
@@ -218,20 +220,18 @@ describe('hooks', () => {
     it('should gracefully handle the client promise rejecting after timeout', async () => {
       readySuccess = false;
       activateMock.mockReturnValue('12345');
-      getOnReadyPromise = () =>
-        new Promise((res, rej) => {
-          setTimeout(() => rej('some error with user'), mockDelay);
-        });
+      getOnReadyPromise = (): Promise<void> =>
+        new Promise((_, rej) => setTimeout(() => rej(REJECTION_REASON), mockDelay));
 
       render(
         <OptimizelyProvider optimizely={optimizelyMock}>
           <MyExperimentComponent options={{ timeout: mockDelay }} />
         </OptimizelyProvider>
       );
-      await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('null|false|false')); // initial render
 
-      await new Promise(r => setTimeout(r, mockDelay * 3));
-      await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('null|false|false'));
+      await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('null|false|false')); // initial render
+      // await new Promise(r => setTimeout(r, mockDelay * 3));
+      // await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('null|false|false'));
     });
 
     it('should re-render when the user attributes change using autoUpdate', async () => {
@@ -481,18 +481,16 @@ describe('hooks', () => {
     it('should gracefully handle the client promise rejecting after timeout', async () => {
       readySuccess = false;
       isFeatureEnabledMock.mockReturnValue(true);
-      getOnReadyPromise = () =>
-        new Promise((res, rej) => {
-          setTimeout(() => rej('some error with user'), mockDelay);
-        });
+      getOnReadyPromise = (): Promise<void> =>
+        new Promise((_, rej) => setTimeout(() => rej(REJECTION_REASON), mockDelay));
 
       render(
         <OptimizelyProvider optimizely={optimizelyMock}>
           <MyFeatureComponent options={{ timeout: mockDelay }} />
         </OptimizelyProvider>
       );
-      await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('false|{}|false|false')); // initial render
 
+      await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('false|{}|false|false')); // initial render
       await new Promise(r => setTimeout(r, mockDelay * 3));
       await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('false|{}|false|false'));
     });
@@ -737,15 +735,15 @@ describe('hooks', () => {
     it('should gracefully handle the client promise rejecting after timeout', async () => {
       readySuccess = false;
       decideMock.mockReturnValue({ ...defaultDecision });
-      getOnReadyPromise = () =>
-        new Promise((res, rej) => {
-          setTimeout(() => rej('some error with user'), mockDelay);
-        });
+      getOnReadyPromise = (): Promise<void> =>
+        new Promise((_, rej) => setTimeout(() => rej(REJECTION_REASON), mockDelay));
+        
       render(
         <OptimizelyProvider optimizely={optimizelyMock}>
           <MyDecideComponent options={{ timeout: mockDelay }} />
         </OptimizelyProvider>
       );
+
       await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('false|{}|false|false')); // initial render
       await new Promise(r => setTimeout(r, mockDelay * 3));
       await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('false|{}|false|false'));

--- a/src/hooks.spec.tsx
+++ b/src/hooks.spec.tsx
@@ -84,7 +84,7 @@ describe('hooks', () => {
   beforeEach(() => {
     getOnReadyPromise = ({ timeout = 0 }: any): Promise<OnReadyResult> =>
       new Promise(resolve => {
-        setTimeout(function () {
+        setTimeout(function() {
           resolve(
             Object.assign(
               {
@@ -117,13 +117,13 @@ describe('hooks', () => {
       getVuid: jest.fn().mockReturnValue('vuid_95bf72cebc774dfd8e8e580a5a1'),
       onUserUpdate: jest.fn().mockImplementation(handler => {
         userUpdateCallbacks.push(handler);
-        return () => { };
+        return () => {};
       }),
       notificationCenter: {
         addNotificationListener: jest.fn().mockImplementation((type, handler) => {
           notificationListenerCallbacks.push(handler);
         }),
-        removeNotificationListener: jest.fn().mockImplementation(id => { }),
+        removeNotificationListener: jest.fn().mockImplementation(id => {}),
       },
       user: {
         id: 'testuser',
@@ -134,7 +134,7 @@ describe('hooks', () => {
       getIsUsingSdkKey: () => true,
       onForcedVariationsUpdate: jest.fn().mockImplementation(handler => {
         forcedVariationUpdateCallbacks.push(handler);
-        return () => { };
+        return () => {};
       }),
       getForcedVariations: jest.fn().mockReturnValue({}),
       decide: decideMock,
@@ -294,7 +294,7 @@ describe('hooks', () => {
 
     it('should re-render after the client becomes ready', async () => {
       readySuccess = false;
-      let resolveReadyPromise: (result: { success: boolean; dataReadyPromise: Promise<any>; }) => void;
+      let resolveReadyPromise: (result: { success: boolean; dataReadyPromise: Promise<any> }) => void;
       const readyPromise: Promise<any> = new Promise(res => {
         resolveReadyPromise = (result): void => {
           readySuccess = true;
@@ -560,7 +560,7 @@ describe('hooks', () => {
 
     it('should re-render after the client becomes ready', async () => {
       readySuccess = false;
-      let resolveReadyPromise: (result: { success: boolean; dataReadyPromise: Promise<any>; }) => void;
+      let resolveReadyPromise: (result: { success: boolean; dataReadyPromise: Promise<any> }) => void;
       const readyPromise: Promise<any> = new Promise(res => {
         resolveReadyPromise = (result): void => {
           readySuccess = true;
@@ -816,7 +816,7 @@ describe('hooks', () => {
 
     it('should re-render after the client becomes ready', async () => {
       readySuccess = false;
-      let resolveReadyPromise: (result: { success: boolean; dataReadyPromise: Promise<any>; }) => void;
+      let resolveReadyPromise: (result: { success: boolean; dataReadyPromise: Promise<any> }) => void;
       const readyPromise: Promise<any> = new Promise(res => {
         resolveReadyPromise = (result): void => {
           readySuccess = true;

--- a/src/hooks.spec.tsx
+++ b/src/hooks.spec.tsx
@@ -223,12 +223,7 @@ describe('hooks', () => {
       readySuccess = false;
       activateMock.mockReturnValue('12345');
       getOnReadyPromise = (): Promise<void> =>
-        new Promise((_, rej) =>
-          setTimeout(() => {
-            console.log(`>>> calling rej after ${mockDelay}`);
-            rej(REJECTION_REASON);
-          }, mockDelay)
-        );
+        new Promise((_, rej) => setTimeout(() => rej(REJECTION_REASON), mockDelay));
 
       render(
         <OptimizelyProvider optimizely={optimizelyMock}>
@@ -236,12 +231,8 @@ describe('hooks', () => {
         </OptimizelyProvider>
       );
 
-      // initial render
-      await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('null|false|false'));
+      jest.advanceTimersByTime(mockDelay + 1);
 
-      jest.advanceTimersByTime(mockDelay);
-
-      // check that the component still has the same rendering
       await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('null|false|false'));
 
       jest.useRealTimers();
@@ -492,6 +483,8 @@ describe('hooks', () => {
     });
 
     it('should gracefully handle the client promise rejecting after timeout', async () => {
+      jest.useFakeTimers();
+
       readySuccess = false;
       isFeatureEnabledMock.mockReturnValue(true);
       getOnReadyPromise = (): Promise<void> =>
@@ -503,9 +496,11 @@ describe('hooks', () => {
         </OptimizelyProvider>
       );
 
-      await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('false|{}|false|false')); // initial render
-      await new Promise(r => setTimeout(r, mockDelay * 3));
+      jest.advanceTimersByTime(mockDelay + 1);
+
       await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('false|{}|false|false'));
+
+      jest.useRealTimers();
     });
 
     it('should re-render when the user attributes change using autoUpdate', async () => {
@@ -746,6 +741,8 @@ describe('hooks', () => {
     });
 
     it('should gracefully handle the client promise rejecting after timeout', async () => {
+      jest.useFakeTimers();
+
       readySuccess = false;
       decideMock.mockReturnValue({ ...defaultDecision });
       getOnReadyPromise = (): Promise<void> =>
@@ -757,9 +754,11 @@ describe('hooks', () => {
         </OptimizelyProvider>
       );
 
-      await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('false|{}|false|false')); // initial render
-      await new Promise(r => setTimeout(r, mockDelay * 3));
+      jest.advanceTimersByTime(mockDelay + 1);
+
       await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('false|{}|false|false'));
+
+      jest.useRealTimers();
     });
 
     it('should re-render when the user attributes change using autoUpdate', async () => {

--- a/src/hooks.spec.tsx
+++ b/src/hooks.spec.tsx
@@ -84,7 +84,7 @@ describe('hooks', () => {
   beforeEach(() => {
     getOnReadyPromise = ({ timeout = 0 }: any): Promise<OnReadyResult> =>
       new Promise(resolve => {
-        setTimeout(function() {
+        setTimeout(function () {
           resolve(
             Object.assign(
               {
@@ -117,13 +117,13 @@ describe('hooks', () => {
       getVuid: jest.fn().mockReturnValue('vuid_95bf72cebc774dfd8e8e580a5a1'),
       onUserUpdate: jest.fn().mockImplementation(handler => {
         userUpdateCallbacks.push(handler);
-        return () => {};
+        return () => { };
       }),
       notificationCenter: {
         addNotificationListener: jest.fn().mockImplementation((type, handler) => {
           notificationListenerCallbacks.push(handler);
         }),
-        removeNotificationListener: jest.fn().mockImplementation(id => {}),
+        removeNotificationListener: jest.fn().mockImplementation(id => { }),
       },
       user: {
         id: 'testuser',
@@ -134,7 +134,7 @@ describe('hooks', () => {
       getIsUsingSdkKey: () => true,
       onForcedVariationsUpdate: jest.fn().mockImplementation(handler => {
         forcedVariationUpdateCallbacks.push(handler);
-        return () => {};
+        return () => { };
       }),
       getForcedVariations: jest.fn().mockReturnValue({}),
       decide: decideMock,
@@ -294,7 +294,7 @@ describe('hooks', () => {
 
     it('should re-render after the client becomes ready', async () => {
       readySuccess = false;
-      let resolveReadyPromise: (result: { success: boolean; dataReadyPromise: Promise<any> }) => void;
+      let resolveReadyPromise: (result: { success: boolean; dataReadyPromise: Promise<any>; }) => void;
       const readyPromise: Promise<any> = new Promise(res => {
         resolveReadyPromise = (result): void => {
           readySuccess = true;
@@ -560,7 +560,7 @@ describe('hooks', () => {
 
     it('should re-render after the client becomes ready', async () => {
       readySuccess = false;
-      let resolveReadyPromise: (result: { success: boolean; dataReadyPromise: Promise<any> }) => void;
+      let resolveReadyPromise: (result: { success: boolean; dataReadyPromise: Promise<any>; }) => void;
       const readyPromise: Promise<any> = new Promise(res => {
         resolveReadyPromise = (result): void => {
           readySuccess = true;
@@ -816,7 +816,7 @@ describe('hooks', () => {
 
     it('should re-render after the client becomes ready', async () => {
       readySuccess = false;
-      let resolveReadyPromise: (result: { success: boolean; dataReadyPromise: Promise<any> }) => void;
+      let resolveReadyPromise: (result: { success: boolean; dataReadyPromise: Promise<any>; }) => void;
       const readyPromise: Promise<any> = new Promise(res => {
         resolveReadyPromise = (result): void => {
           readySuccess = true;

--- a/src/withOptimizely.spec.tsx
+++ b/src/withOptimizely.spec.tsx
@@ -53,6 +53,7 @@ describe('withOptimizely', () => {
     optimizelyClient = ({
       setUser: jest.fn(),
       getVuid: jest.fn(),
+      onReady: jest.fn(),
     } as unknown) as ReactSDKClient;
   });
 

--- a/src/withOptimizely.spec.tsx
+++ b/src/withOptimizely.spec.tsx
@@ -1,11 +1,11 @@
 /**
- * Copyright 2018-2019, Optimizely
+ * Copyright 2018-2019, 2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /// <reference types="jest" />
 
 import * as React from 'react';
@@ -34,7 +35,7 @@ class InnerComponent extends React.Component<TestProps, any> {
     super(props);
   }
 
-  render() {
+  render(): JSX.Element {
     return (
       <div>
         <span data-testid="props-of-component">{JSON.stringify({ ...this.props })}</span>
@@ -51,6 +52,7 @@ describe('withOptimizely', () => {
   beforeEach(() => {
     optimizelyClient = ({
       setUser: jest.fn(),
+      getVuid: jest.fn(),
     } as unknown) as ReactSDKClient;
   });
 
@@ -160,7 +162,7 @@ describe('withOptimizely', () => {
       )
     );
 
-    expect(optimizelyClient.setUser).not.toHaveBeenCalled();
+    expect(optimizelyClient.setUser).toHaveBeenCalled();
   });
 
   it('should inject the isServerSide prop', async () => {
@@ -202,10 +204,11 @@ describe('withOptimizely', () => {
         <OptimizelyInput ref={inputRef} defaultValue="hi" />
       </OptimizelyProvider>
     );
+    expect(inputRef).toBeDefined();
     expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
-    expect(typeof inputRef.current!.focus).toBe('function');
+    expect(typeof inputRef.current?.focus).toBe('function');
     const inputNode: HTMLInputElement = screen.getByTestId('input-element');
-    expect(inputRef.current!).toBe(inputNode);
+    expect(inputRef.current).toBe(inputNode);
   });
 
   it('should hoist non-React statics', () => {

--- a/src/withOptimizely.spec.tsx
+++ b/src/withOptimizely.spec.tsx
@@ -58,7 +58,7 @@ describe('withOptimizely', () => {
   });
 
   describe('when userId / userAttributes props are provided', () => {
-    it('should call setUser with the correct user id / attributes', () => {
+    it('should call setUser with the correct user id / attributes', async () => {
       const attributes = {
         foo: 'bar',
       };
@@ -69,13 +69,13 @@ describe('withOptimizely', () => {
         </OptimizelyProvider>
       );
 
-      expect(optimizelyClient.setUser).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(optimizelyClient.setUser).toHaveBeenCalledTimes(1));
       expect(optimizelyClient.setUser).toHaveBeenCalledWith({ id: userId, attributes });
     });
   });
 
   describe('when only userId prop is provided', () => {
-    it('should call setUser with the correct user id / attributes', () => {
+    it('should call setUser with the correct user id / attributes', async () => {
       const userId = 'jordan';
       render(
         <OptimizelyProvider optimizely={optimizelyClient} timeout={200} userId={userId}>
@@ -83,7 +83,7 @@ describe('withOptimizely', () => {
         </OptimizelyProvider>
       );
 
-      expect(optimizelyClient.setUser).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(optimizelyClient.setUser).toHaveBeenCalledTimes(1));
       expect(optimizelyClient.setUser).toHaveBeenCalledWith({
         id: userId,
         attributes: {},
@@ -92,7 +92,7 @@ describe('withOptimizely', () => {
   });
 
   describe(`when the user prop is passed only with "id"`, () => {
-    it('should call setUser with the correct user id / attributes', () => {
+    it('should call setUser with the correct user id / attributes', async () => {
       const userId = 'jordan';
       render(
         <OptimizelyProvider optimizely={optimizelyClient} timeout={200} user={{ id: userId }}>
@@ -100,7 +100,7 @@ describe('withOptimizely', () => {
         </OptimizelyProvider>
       );
 
-      expect(optimizelyClient.setUser).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(optimizelyClient.setUser).toHaveBeenCalledTimes(1));
       expect(optimizelyClient.setUser).toHaveBeenCalledWith({
         id: userId,
         attributes: {},
@@ -109,7 +109,7 @@ describe('withOptimizely', () => {
   });
 
   describe(`when the user prop is passed with "id" and "attributes"`, () => {
-    it('should call setUser with the correct user id / attributes', () => {
+    it('should call setUser with the correct user id / attributes', async () => {
       const userId = 'jordan';
       const attributes = { foo: 'bar' };
       render(
@@ -118,7 +118,7 @@ describe('withOptimizely', () => {
         </OptimizelyProvider>
       );
 
-      expect(optimizelyClient.setUser).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(optimizelyClient.setUser).toHaveBeenCalledTimes(1));
       expect(optimizelyClient.setUser).toHaveBeenCalledWith({
         id: userId,
         attributes,
@@ -127,7 +127,7 @@ describe('withOptimizely', () => {
   });
 
   describe('when both the user prop and userId / userAttributes props are passed', () => {
-    it('should respect the user object prop', () => {
+    it('should respect the user object prop', async () => {
       const userId = 'jordan';
       const attributes = { foo: 'bar' };
       render(
@@ -142,7 +142,7 @@ describe('withOptimizely', () => {
         </OptimizelyProvider>
       );
 
-      expect(optimizelyClient.setUser).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(optimizelyClient.setUser).toHaveBeenCalledTimes(1));
       expect(optimizelyClient.setUser).toHaveBeenCalledWith({
         id: userId,
         attributes,
@@ -190,13 +190,9 @@ describe('withOptimizely', () => {
     const OptimizelyInput = withOptimizely(ForwardingFancyInput);
     const inputRef: React.RefObject<HTMLInputElement> = React.createRef();
 
-    const optimizelyMock: ReactSDKClient = ({
-      setUser: jest.fn(),
-    } as unknown) as ReactSDKClient;
-
     render(
       <OptimizelyProvider
-        optimizely={optimizelyMock}
+        optimizely={optimizelyClient}
         timeout={200}
         user={{ id: 'jordan' }}
         userAttributes={{ plan_type: 'bronze' }}


### PR DESCRIPTION
## Summary
- When `OptimizelyProvider` is used without the `user?` or `userId?` props, we should retrieve and use the VUID for `optimizely.setUser()`
- Refactored logic from `constructor()` of provider into lifecycle method `componentDidMount()`
- Test updates to support `getVuid()`
- Added types to remove warns.

## Test plan

- Existing and updated unit tests are expected to pass
- Integration and e2e test should continue to pass
- I'd like to review with @jaeopt for AAT function reqs.

## Issues
- FSSDK-9654