### PR TITLE
[FSSDK-9623] chore: prep 3.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.0.1] - February 27, 2024
+
+### Changed
+- Updated `@optimizely/optimizely-sdk` to version `5.0.1` ([#242](https://github.com/optimizely/react-sdk/pull/242))
+- Updated Dependabot alerts ([#239](https://github.com/optimizely/react-sdk/pull/239), [#241](https://github.com/optimizely/react-sdk/pull/241))
+
 ## [3.0.0] - January 24, 2024
 
 ### New Features  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/react-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "React SDK for Optimizely Feature Experimentation, Optimizely Full Stack (legacy), and Optimizely Rollouts",
   "homepage": "https://github.com/optimizely/react-sdk",
   "repository": "https://github.com/optimizely/react-sdk",

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2023, Optimizely
+ * Copyright 2019-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -123,7 +123,7 @@ describe('ReactSDKClient', () => {
     expect(createInstanceSpy).toBeCalledWith({
       ...config,
       clientEngine: 'react-sdk',
-      clientVersion: '3.0.0',
+      clientVersion: '3.0.1',
     });
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2023, Optimizely
+ * Copyright 2019-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/client.ts
+++ b/src/client.ts
@@ -43,7 +43,7 @@ export interface OnReadyResult extends ResolveResult {
 }
 
 const REACT_SDK_CLIENT_ENGINE = 'react-sdk';
-const REACT_SDK_CLIENT_VERSION = '3.0.0';
+const REACT_SDK_CLIENT_VERSION = '3.0.1';
 
 export const DefaultUser: UserInfo = {
   id: null,


### PR DESCRIPTION
## Summary
- Bump version semantic version number of the React SDK
- Update CHANGELOG

## Test plan

- Unit and end-to-end tests should pass

## Issues
- FSSDK-9623