### PR TITLE
[FSSDK-9984] chore: prepare for release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## [3.1.0] - April 9, 2024
 
 ### Bug Fixes
-- For Issues [#235](https://github.com/optimizely/react-sdk/issues/235) & [#236](https://github.com/optimizely/react-sdk/issues/236) ([#255](https://github.com/optimizely/react-sdk/pull/255))
+- Error initializing client. The core client or user promise(s) rejected.
+ ([#255](https://github.com/optimizely/react-sdk/pull/255))
+- Unable to determine if feature "{your-feature-key}" is enabled because User ID is not set([#255](https://github.com/optimizely/react-sdk/pull/255))
 
 ### Changed
 - Bumped Optimizely JS SDK version in use ([#255](https://github.com/optimizely/react-sdk/pull/255))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [3.1.0] - April 9, 2024
+
+### Bug Fixes
+- For Issues [#235](https://github.com/optimizely/react-sdk/issues/235) & [#236](https://github.com/optimizely/react-sdk/issues/236) ([#255](https://github.com/optimizely/react-sdk/pull/255))
+
+### Changed
+- Bumped Optimizely JS SDK version in use ([#255](https://github.com/optimizely/react-sdk/pull/255))
+- Resolve dependabot dependency vulnerabilities ([#245](https://github.com/optimizely/react-sdk/pull/245), [#247](https://github.com/optimizely/react-sdk/pull/247), [#248](https://github.com/optimizely/react-sdk/pull/248), [#251](https://github.com/optimizely/react-sdk/pull/251), [#253](https://github.com/optimizely/react-sdk/pull/253))
+- Add node versions during testing ([#249](https://github.com/optimizely/react-sdk/pull/249))
+
 ## [3.0.1] - February 27, 2024
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/react-sdk",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "React SDK for Optimizely Feature Experimentation, Optimizely Full Stack (legacy), and Optimizely Rollouts",
   "homepage": "https://github.com/optimizely/react-sdk",
   "repository": "https://github.com/optimizely/react-sdk",

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -127,7 +127,7 @@ describe('ReactSDKClient', () => {
     expect(createInstanceSpy).toBeCalledWith({
       ...config,
       clientEngine: 'react-sdk',
-      clientVersion: '3.0.1',
+      clientVersion: '3.1.0',
     });
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,7 +47,7 @@ export interface OnReadyResult extends ResolveResult {
 }
 
 const REACT_SDK_CLIENT_ENGINE = 'react-sdk';
-const REACT_SDK_CLIENT_VERSION = '3.0.1';
+const REACT_SDK_CLIENT_VERSION = '3.1.0';
 
 export const DefaultUser: UserInfo = {
   id: null,


### PR DESCRIPTION
## Summary
- Bump semantic version of React SDK
- Update CHANGELOG to summarize release changes.

## Test plan
- No code changes; expecting existing unit tests to succeed
 
## Issues
- FSSDK-9984