### PR TITLE
ODP integration error resolve by removing unnecessary qualified segment fetching

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -364,7 +364,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
   }
 
   public async fetchQualifiedSegments(options?: optimizely.OptimizelySegmentOption[]): Promise<boolean> {
-    if (this.odpExplicitlyOff) {
+    if (this.odpExplicitlyOff || !this._client?.getProjectConfig()?.odpIntegrationConfig?.integrated) {
       return true;
     }
 


### PR DESCRIPTION
## Summary
If the project does not have ODP integration enabled, sdk should not call the fetchQualifiedSegments method.

## Test plan
- Existing test should pass
## Issues
- [FSSDK-10198](https://jira.sso.episerver.net/browse/FSSDK-10198)