### PR TITLE
[FSSDK-10198] odp not integrated error

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@optimizely/optimizely-sdk": "^5.3.0",
+    "@optimizely/optimizely-sdk": "^5.3.2",
     "hoist-non-react-statics": "^3.3.0",
     "prop-types": "^15.6.2",
     "utility-types": "^2.1.0 || ^3.0.0"

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -79,6 +79,7 @@ describe('ReactSDKClient', () => {
       getFeatureVariableString: jest.fn(() => null),
       getOptimizelyConfig: jest.fn(() => null),
       getProjectConfig: jest.fn(() => null),
+      isOdpIntegrated: jest.fn(() => true),
       onReady: jest.fn(() => Promise.resolve({ success: false })),
       close: jest.fn(),
       getVuid: jest.fn(),

--- a/src/client.ts
+++ b/src/client.ts
@@ -54,7 +54,8 @@ export const DefaultUser: UserInfo = {
   attributes: {},
 };
 
-export interface ReactSDKClient extends Omit<optimizely.Client, 'createUserContext' | 'getProjectConfig'> {
+export interface ReactSDKClient
+  extends Omit<optimizely.Client, 'createUserContext' | 'getProjectConfig' | 'isOdpIntegrated'> {
   user: UserInfo;
 
   onReady(opts?: { timeout?: number }): Promise<any>;
@@ -368,7 +369,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
       return false;
     }
 
-    if (this.odpExplicitlyOff || !this._client?.getProjectConfig()?.odpIntegrationConfig?.integrated) {
+    if (this.odpExplicitlyOff || !this._client?.isOdpIntegrated()) {
       return true;
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -364,12 +364,12 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
   }
 
   public async fetchQualifiedSegments(options?: optimizely.OptimizelySegmentOption[]): Promise<boolean> {
-    if (this.odpExplicitlyOff || !this._client?.getProjectConfig()?.odpIntegrationConfig?.integrated) {
-      return true;
-    }
-
     if (!this.userContext) {
       return false;
+    }
+
+    if (this.odpExplicitlyOff || !this._client?.getProjectConfig()?.odpIntegrationConfig?.integrated) {
+      return true;
     }
 
     return await this.userContext.fetchQualifiedSegments(options);

--- a/src/client.ts
+++ b/src/client.ts
@@ -364,7 +364,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
   }
 
   public async fetchQualifiedSegments(options?: optimizely.OptimizelySegmentOption[]): Promise<boolean> {
-    if (this.odpExplicitlyOff) {
+    if (this.odpExplicitlyOff || !this._client?.getProjectConfig()?.odpIntegrationConfig?.integrated) {
       return true;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -656,9 +656,9 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@optimizely/optimizely-sdk@^5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-5.3.0.tgz#dd1ca9d19287b31675d2f95c24234e074ade9a8b"
-  integrity sha512-PzfjcApCvcHGir8XWSG3IBaOJXvPADjqpzXypEWTfArrONA3FlmqdnwDAlxF4b557fo/UZI6ZCyj3AWrG8cprg==
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/@optimizely/optimizely-sdk/-/optimizely-sdk-5.3.2.tgz#4a4918485c9319b2237f6e32d901c3ff7e998051"
+  integrity sha512-9d3sRusZfkN+CCq7C7DXp0bKam+dx2cDPPdcBQxLfwtTKFulzf6kGwnz4pVTtjwQ89vbJz10iJNMmD9qtSduPw==
   dependencies:
     decompress-response "^4.2.1"
     json-schema "^0.4.0"


### PR DESCRIPTION
## Summary
If the project does not have ODP integration enabled, sdk should not call the fetchQualifiedSegments method.

## Test plan
Existing test should pass

## Issues
[FSSDK-10198](https://jira.sso.episerver.net/browse/FSSDK-10198)