### PR TITLE
[FSSDK-10198] Prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.1.1] - May 22, 2024
+
+### Bug Fixes
+- ODP integration error. ([#262](https://github.com/optimizely/react-sdk/pull/262))
+
 ## [3.1.0] - April 9, 2024
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/react-sdk",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "React SDK for Optimizely Feature Experimentation, Optimizely Full Stack (legacy), and Optimizely Rollouts",
   "homepage": "https://github.com/optimizely/react-sdk",
   "repository": "https://github.com/optimizely/react-sdk",

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -128,7 +128,7 @@ describe('ReactSDKClient', () => {
     expect(createInstanceSpy).toBeCalledWith({
       ...config,
       clientEngine: 'react-sdk',
-      clientVersion: '3.1.0',
+      clientVersion: '3.1.1',
     });
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,7 +47,7 @@ export interface OnReadyResult extends ResolveResult {
 }
 
 const REACT_SDK_CLIENT_ENGINE = 'react-sdk';
-const REACT_SDK_CLIENT_VERSION = '3.1.0';
+const REACT_SDK_CLIENT_VERSION = '3.1.1';
 
 export const DefaultUser: UserInfo = {
   id: null,


### PR DESCRIPTION
## Summary
Addressed issue - #260 

---
![image-2024-05-07-14-55-32-658](https://github.com/optimizely/react-sdk/assets/169046794/d41086e9-383a-4471-8db5-2d4070056c9a)

SDK is calling `fetchQuaifiedSegments` method for clients who do not have ODP integrated in their project.  An additional constraint is now in place to avoid that. 

## Test Plan
Existing test should pass

## Issues
- [FSSDK-10198](https://jira.sso.episerver.net/browse/FSSDK-10198)