### PR TITLE
[FSSDK-9871] Hook for track events

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ function SignupButton() {
 }
 ```
 
-Use the `withOptimizely` HoC for tracking.
+Or you can use the `withOptimizely` HoC.
 
 ```jsx
 import { withOptimizely } from '@optimizely/react-sdk';

--- a/README.md
+++ b/README.md
@@ -328,6 +328,23 @@ function MyComponent() {
 ```
 
 ### Tracking
+Use the built-in `useTrackEvents` hook to access the `track` method of optimizely instance
+
+```jsx
+function SignupButton() {
+  const [track, clientReady, didTimeout] = useTrackEvents()
+
+  const handleClick = () => {
+    if(clientReady) {
+      track('signup-clicked')
+    }
+  }
+
+  return (
+    <button onClick={handleClick}>Signup</button>
+  )
+}
+```
 
 Use the `withOptimizely` HoC for tracking.
 

--- a/README.md
+++ b/README.md
@@ -328,11 +328,13 @@ function MyComponent() {
 ```
 
 ### Tracking
-Use the built-in `useTrackEvents` hook to access the `track` method of optimizely instance
+Use the built-in `useTrackEvent` hook to access the `track` method of optimizely instance
 
 ```jsx
+import { useTrackEvent } from '@optimizely/react-sdk';
+
 function SignupButton() {
-  const [track, clientReady, didTimeout] = useTrackEvents()
+  const [track, clientReady, didTimeout] = useTrackEvent()
 
   const handleClick = () => {
     if(clientReady) {

--- a/src/hooks.spec.tsx
+++ b/src/hooks.spec.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022, 2023 Optimizely
+ * Copyright 2022, 2023, 2024 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import '@testing-library/jest-dom/extend-expect';
 
 import { OptimizelyProvider } from './Provider';
 import { OnReadyResult, ReactSDKClient, VariableValuesObject } from './client';
-import { useExperiment, useFeature, useDecision, useTrackEvents, hooksLogger } from './hooks';
+import { useExperiment, useFeature, useDecision, useTrackEvent, hooksLogger } from './hooks';
 import { OptimizelyDecision } from './utils';
 const defaultDecision: OptimizelyDecision = {
   enabled: false,
@@ -1048,13 +1048,13 @@ describe('hooks', () => {
       await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('false|{}|true|false'));
     });
   });
-  describe('useTrackEvents', () => {
+  describe('useTrackEvent', () => {
     it('returns track method and false states when optimizely is not provided', () => {
       const wrapper = ({ children }: { children: React.ReactNode }): React.ReactElement => {
         //@ts-ignore
         return <OptimizelyProvider>{children}</OptimizelyProvider>;
       };
-      const { result } = renderHook(() => useTrackEvents(), { wrapper });
+      const { result } = renderHook(() => useTrackEvent(), { wrapper });
       expect(result.current[0]).toBeInstanceOf(Function);
       expect(result.current[1]).toBe(false);
       expect(result.current[2]).toBe(false);
@@ -1067,7 +1067,7 @@ describe('hooks', () => {
         </OptimizelyProvider>
       );
 
-      const { result } = renderHook(() => useTrackEvents(), { wrapper });
+      const { result } = renderHook(() => useTrackEvent(), { wrapper });
       expect(result.current[0]).toBeInstanceOf(Function);
       expect(typeof result.current[1]).toBe('boolean');
       expect(typeof result.current[2]).toBe('boolean');
@@ -1078,7 +1078,7 @@ describe('hooks', () => {
         //@ts-ignore
         return <OptimizelyProvider>{children}</OptimizelyProvider>;
       };
-      const { result } = renderHook(() => useTrackEvents(), { wrapper });
+      const { result } = renderHook(() => useTrackEvent(), { wrapper });
       result.current[0]('eventKey');
       expect(hooksLogger.error).toHaveBeenCalledTimes(1);
     });
@@ -1092,7 +1092,7 @@ describe('hooks', () => {
         </OptimizelyProvider>
       );
 
-      const { result } = renderHook(() => useTrackEvents(), { wrapper });
+      const { result } = renderHook(() => useTrackEvent(), { wrapper });
       result.current[0]('eventKey');
       expect(hooksLogger.error).toHaveBeenCalledTimes(1);
     });

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -87,7 +87,7 @@ interface UseDecision {
   ];
 }
 
-interface UseTrackEvents {
+interface UseTrackEvent {
   (): [(...args: Parameters<ReactSDKClient['track']>) => void, boolean, boolean];
 }
 
@@ -505,7 +505,7 @@ export const useDecision: UseDecision = (flagKey, options = {}, overrides = {}) 
   return [state.decision, state.clientReady, state.didTimeout];
 };
 
-export const useTrackEvents: UseTrackEvents = () => {
+export const useTrackEvent: UseTrackEvent = () => {
   const { optimizely, isServerSide, timeout } = useContext(OptimizelyContext);
   const isClientReady = !!(isServerSide || optimizely?.isReady());
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@
 export { OptimizelyContext, OptimizelyContextConsumer, OptimizelyContextProvider } from './Context';
 export { OptimizelyProvider } from './Provider';
 export { OptimizelyFeature } from './Feature';
-export { useFeature, useExperiment, useDecision } from './hooks';
+export { useFeature, useExperiment, useDecision, useTrackEvents } from './hooks';
 export { withOptimizely, WithOptimizelyProps, WithoutOptimizelyProps } from './withOptimizely';
 export { OptimizelyExperiment } from './Experiment';
 export { OptimizelyVariation } from './Variation';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2019, 2023 Optimizely
+ * Copyright 2018-2019, 2023, 2024 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 export { OptimizelyContext, OptimizelyContextConsumer, OptimizelyContextProvider } from './Context';
 export { OptimizelyProvider } from './Provider';
 export { OptimizelyFeature } from './Feature';
-export { useFeature, useExperiment, useDecision, useTrackEvents } from './hooks';
+export { useFeature, useExperiment, useDecision, useTrackEvent } from './hooks';
 export { withOptimizely, WithOptimizelyProps, WithoutOptimizelyProps } from './withOptimizely';
 export { OptimizelyExperiment } from './Experiment';
 export { OptimizelyVariation } from './Variation';


### PR DESCRIPTION
## Summary
- A functional approach to track events.
- `useTrackEvents` hook is exposed similar to the existing `useDecision` hook.

## Test plan
New test cases have been added to support the new functionality

## Issues
[FSSDK-9871](https://jira.sso.episerver.net/browse/FSSDK-9871)