### PR TITLE
[FSSDK-10554] Can't set log level error

### DIFF
--- a/src/logger.tsx
+++ b/src/logger.tsx
@@ -16,7 +16,8 @@
 
 import * as optimizely from '@optimizely/optimizely-sdk';
 import { sprintf } from './utils';
-const logHandler = optimizely.logging.createLogger({ prefix: '[React-SDK]' });
+
+const logHandler = optimizely.getLogger('ReactSDK');
 
 export const logger = {
   warn: (msg: string, ...splat: any[]) => {


### PR DESCRIPTION
## Summary
 - #265 has been addressed. 
 - Instead of creating a new log for the React client,  we can reuse the global log that `Optimizely` already provides with its `getLogger` API. That way we can configure the log system as a whole from a single source. 
 - FYI, we are already using `getLogger` for [hooks](https://github.com/optimizely/react-sdk/blob/c16ea02cb423c78b9de09b2e78e0d40b590ee38a/src/hooks.ts#L27) and [providers](https://github.com/optimizely/react-sdk/blob/c16ea02cb423c78b9de09b2e78e0d40b590ee38a/src/Provider.tsx#L26C1-L26C50).
## Test plan
Existing test should pass

## Issues
[FSSDK-10554](https://jira.sso.episerver.net/browse/FSSDK-10554)