### PR TITLE
[FSSDK-10438] prioritize integration test before unit test run

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -7,6 +7,12 @@ on:
     branches: [ master ]
 
 jobs:
+  integration_tests:    
+    name: Run integration tests
+    uses: optimizely/react-sdk/.github/workflows/integration_test.yml@master
+    secrets:
+      CI_USER_TOKEN: ${{ secrets.CI_USER_TOKEN }}
+      TRAVIS_COM_TOKEN: ${{ secrets.TRAVIS_COM_TOKEN }}       
   unitTests:    
     name: Run Unit Tests (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
@@ -24,7 +30,6 @@ jobs:
       run: yarn install
     - name: Run tests
       run: yarn test
-  
   coverage:
     name: Jest Coverage Report
     runs-on: ubuntu-latest
@@ -36,10 +41,4 @@ jobs:
         custom-title: 'Jest Coverage Report'
         package-manager: 'yarn'
 
-  integration_tests:    
-    name: Run integration tests
-    needs: [ unitTests ]
-    uses: optimizely/react-sdk/.github/workflows/integration_test.yml@master
-    secrets:
-      CI_USER_TOKEN: ${{ secrets.CI_USER_TOKEN }}
-      TRAVIS_COM_TOKEN: ${{ secrets.TRAVIS_COM_TOKEN }}         
+    

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -7,12 +7,6 @@ on:
     branches: [ master ]
 
 jobs:
-  integration_tests:    
-    name: Run integration tests
-    uses: optimizely/react-sdk/.github/workflows/integration_test.yml@master
-    secrets:
-      CI_USER_TOKEN: ${{ secrets.CI_USER_TOKEN }}
-      TRAVIS_COM_TOKEN: ${{ secrets.TRAVIS_COM_TOKEN }}       
   unitTests:    
     name: Run Unit Tests (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
@@ -30,6 +24,13 @@ jobs:
       run: yarn install
     - name: Run tests
       run: yarn test
+  integration_tests:    
+    name: Run integration tests
+    needs: [ unitTests ]
+    uses: optimizely/react-sdk/.github/workflows/integration_test.yml@master
+    secrets:
+      CI_USER_TOKEN: ${{ secrets.CI_USER_TOKEN }}
+      TRAVIS_COM_TOKEN: ${{ secrets.TRAVIS_COM_TOKEN }}       
   coverage:
     name: Jest Coverage Report
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
"Integration test" job will trigger a dispatch event to [e2e](https://github.com/optimizely/react-sdk-e2e-tests) repo, and that will create a job and update the commit status of this SDK repo. Now this trigger and round trip takes some time. And by that time PR can get OK status before even receiving the result of the integration test. 

To avoid this , A parallel execution approach is required, and has been implemented. So by the time Unit test and Jest report will be ready, Integration test round trip should be complete with a job and status report

## Test plan
Existing test should pass

## Issues
- [FSSDK-10438](https://jira.sso.episerver.net/browse/FSSDK-10438)