### PR TITLE
[FSSDK-10730] isClientReady logic adjustment

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -240,7 +240,6 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     });
 
     this._client = optimizely.createInstance(configWithClientInfo);
-    this.isClientReady = !!configWithClientInfo.datafile;
     this.isUsingSdkKey = !!configWithClientInfo.sdkKey;
 
     if (this._client) {
@@ -251,7 +250,6 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
           this.isClientReady = clientResult.success;
           this.isUserReady = userResult.success;
           const clientAndUserReady = this.isClientReady && this.isUserReady;
-
           this.clientAndUserReadyPromiseFulfilled = true;
 
           return {

--- a/src/client.ts
+++ b/src/client.ts
@@ -240,6 +240,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     });
 
     this._client = optimizely.createInstance(configWithClientInfo);
+    this.isClientReady = !!this.getOptimizelyConfig();
     this.isUsingSdkKey = !!configWithClientInfo.sdkKey;
 
     if (this._client) {
@@ -249,7 +250,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
         ([userResult, clientResult]) => {
           this.isClientReady = clientResult.success;
           this.isUserReady = userResult.success;
-          const clientAndUserReady = this.isClientReady && this.isUserReady;
+          const clientAndUserReady = this.isReady();
           this.clientAndUserReadyPromiseFulfilled = true;
 
           return {


### PR DESCRIPTION
## Summary
React SDK sets client.isClientReady property to true immediately if datafile presents in the config, before projectConfigManager gets ready, which should not be the case. 

## Test plan
Existing test should pass

## Issues
[FSSDK-10730](https://jira.sso.episerver.net/browse/FSSDK-10730)