### PR TITLE
[FSSDK-8184] override attribute bug fix of track method

### DIFF
--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -1423,7 +1423,7 @@ describe('ReactSDKClient', () => {
         expect(mockFn).toHaveBeenCalledWith('evt1', 'user3', { bla: 'bla' }, { tagKey: 'tagVal' });
       });
 
-      it.only('track with event key, tags, and overrided attributes, calls inner client with valid arguments', () => {
+      it('track with event key, tags, and overrided attributes, calls inner client with valid arguments', () => {
         const mockFn = mockInnerClient.track as jest.Mock;
         instance.track('evt1', { tagKey: 'tagVal' }, { bla: 'bla' });
 

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -1390,36 +1390,46 @@ describe('ReactSDKClient', () => {
       expect(mockFn).toHaveBeenCalledTimes(0);
     });
 
-    it('track works as expected', () => {
-      const mockFn = mockInnerClient.track as jest.Mock;
+    describe('track with different parameters', () => {
+      it('track with only event key, calls inner client with valid arguments', () => {
+        const mockFn = mockInnerClient.track as jest.Mock;
+        instance.track('evt1');
 
-      instance.track('evt1');
+        expect(mockFn).toHaveBeenCalledTimes(1);
+        expect(mockFn).toHaveBeenCalledWith('evt1', 'user1', { foo: 'bar' }, undefined);
+      });
 
-      expect(mockFn).toHaveBeenCalledTimes(1);
-      expect(mockFn).toHaveBeenCalledWith('evt1', 'user1', { foo: 'bar' }, undefined);
+      it('track with event key and overrided user id and attributes, calls inner client with valid arguments', () => {
+        const mockFn = mockInnerClient.track as jest.Mock;
+        instance.track('evt1', 'user2', { bar: 'baz' });
 
-      mockFn.mockReset();
+        expect(mockFn).toHaveBeenCalledTimes(1);
+        expect(mockFn).toHaveBeenCalledWith('evt1', 'user2', { bar: 'baz' }, undefined);
+      });
 
-      instance.track('evt1', 'user2', { bar: 'baz' });
+      it('track with event key and event tags, calls inner client with valid arguments', () => {
+        const mockFn = mockInnerClient.track as jest.Mock;
+        instance.track('evt1', { tagKey: 'tagVal' });
 
-      expect(mockFn).toHaveBeenCalledTimes(1);
-      expect(mockFn).toHaveBeenCalledWith('evt1', 'user2', { bar: 'baz' }, undefined);
+        expect(mockFn).toHaveBeenCalledTimes(1);
+        expect(mockFn).toHaveBeenCalledWith('evt1', 'user1', { foo: 'bar' }, { tagKey: 'tagVal' });
+      });
 
-      mockFn.mockReset();
+      it('track with event key, overrided user id and attributes and event tags, calls inner client with valid arguments', () => {
+        const mockFn = mockInnerClient.track as jest.Mock;
+        instance.track('evt1', 'user3', { bla: 'bla' }, { tagKey: 'tagVal' });
 
-      // Use pre-set user with event tags
-      instance.track('evt1', { tagKey: 'tagVal' });
+        expect(mockFn).toHaveBeenCalledTimes(1);
+        expect(mockFn).toHaveBeenCalledWith('evt1', 'user3', { bla: 'bla' }, { tagKey: 'tagVal' });
+      });
 
-      expect(mockFn).toHaveBeenCalledTimes(1);
-      expect(mockFn).toHaveBeenCalledWith('evt1', 'user1', { foo: 'bar' }, { tagKey: 'tagVal' });
+      it.only('track with event key, tags, and overrided attributes, calls inner client with valid arguments', () => {
+        const mockFn = mockInnerClient.track as jest.Mock;
+        instance.track('evt1', { tagKey: 'tagVal' }, { bla: 'bla' });
 
-      mockFn.mockReset();
-
-      // Use overrides with event tags
-      instance.track('evt1', 'user3', { bla: 'bla' }, { tagKey: 'tagVal' });
-
-      expect(mockFn).toHaveBeenCalledTimes(1);
-      expect(mockFn).toHaveBeenCalledWith('evt1', 'user3', { bla: 'bla' }, { tagKey: 'tagVal' });
+        expect(mockFn).toHaveBeenCalledTimes(1);
+        expect(mockFn).toHaveBeenCalledWith('evt1', 'user1', { bla: 'bla' }, { tagKey: 'tagVal' });
+      });
     });
   });
 

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -1430,6 +1430,14 @@ describe('ReactSDKClient', () => {
         expect(mockFn).toHaveBeenCalledTimes(1);
         expect(mockFn).toHaveBeenCalledWith('evt1', 'user1', { bla: 'bla' }, { tagKey: 'tagVal' });
       });
+
+      it('track with event key, userId undefined, attributes undefined, and event tags, calls inner client with valid arguments', () => {
+        const mockFn = mockInnerClient.track as jest.Mock;
+        instance.track('evt1', undefined, undefined, { tagKey: 'tagVal' });
+
+        expect(mockFn).toHaveBeenCalledTimes(1);
+        expect(mockFn).toHaveBeenCalledWith('evt1', 'user1', { foo: 'bar' }, { tagKey: 'tagVal' });
+      });
     });
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -635,7 +635,6 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     if (typeof overrideUserId !== 'undefined' && typeof overrideUserId !== 'string') {
       eventTags = overrideUserId;
       overrideUserId = undefined;
-      overrideAttributes = undefined;
     }
 
     const user = this.getUserWithOverrides(overrideUserId, overrideAttributes);


### PR DESCRIPTION
## Summary
While checking the second parameter of `OptimizelyReactClient.track`, to decide if its a `userId` or `eventTags`, `overrideAttributes` is set to `undefined` if the second argument is `eventTags`, which should not be the case. userId and attribute overrides are two seperate things.

## Test plan
- Test structure of `track` method of React client has improved
- New test case added to cover this specific scenario

## Issues
- [FSSDK-8184](https://jira.sso.episerver.net/browse/FSSDK-8184)