### PR TITLE
Remove unused dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,10 +521,6 @@ Copyright &copy; 2014 Taylor Hakes
 Copyright &copy; 2014 Forbes Lindesay
 License: [MIT](https://github.com/taylorhakes/promise-polyfill/blob/master/LICENSE)
 
-[**prop-types**](https://github.com/facebook/prop-types)
-Copyright &copy; 2013-present, Facebook, Inc.
-License: [MIT](https://github.com/facebook/prop-types/blob/master/LICENSE)
-
 [**react-is**](https://github.com/facebook/react)
 Copyright &copy; Facebook, Inc. and its affiliates.
 License: [MIT](https://github.com/facebook/react/blob/master/LICENSE)

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@optimizely/optimizely-sdk": "^5.3.4",
     "hoist-non-react-statics": "^3.3.2",
-    "prop-types": "^15.8.1",
     "utility-types": "^2.1.0 || ^3.0.0"
   },
   "peerDependencies": {
@@ -58,7 +57,6 @@
     "@testing-library/react": "^14.3.0",
     "@types/hoist-non-react-statics": "^3.3.5",
     "@types/jest": "^29.5.12",
-    "@types/prop-types": "^15.7.12",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
     "@typescript-eslint/eslint-plugin": "^5.6.2",
@@ -78,7 +76,6 @@
     "rollup": "^3.29.4",
     "rollup-plugin-typescript2": "^0.36.0",
     "ts-jest": "^29.2.3",
-    "tslib": "^2.6.3",
     "typescript": "^5.5.4"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noImplicitAny": true,
-    "importHelpers": false,
     "strictNullChecks": true,
     "noLib": false,
     "emitDecoratorMetadata": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -860,7 +860,7 @@
   dependencies:
     undici-types "~6.13.0"
 
-"@types/prop-types@*", "@types/prop-types@^15.7.12":
+"@types/prop-types@*":
   version "15.7.12"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.12.tgz#12bb1e2be27293c1406acb6af1c3f3a1481d98c6"
   integrity sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==
@@ -4664,7 +4664,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0, tslib@^2.6.2, tslib@^2.6.3:
+tslib@^2.1.0, tslib@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==


### PR DESCRIPTION
## Summary

- Removed `prop-types` and `@types/prop-types` dependencies - as well as reference in `README.md` - as these packages are no longed used.
- Removed unused `tslib` dependency and corresponding redundant TypeScript config option.