### PR TITLE
[FSSDK-10880] override initial user bug adjustment

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout branch
       uses: actions/checkout@v3
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}`
+        token: ${{ secrets.CI_USER_TOKEN || secrets.GITHUB_TOKEN }}`
         repository: 'optimizely/travisci-tools'
         path: 'home/runner/travisci-tools'
         ref: 'master'

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout branch
       uses: actions/checkout@v3
       with:
-        token: ${{ secrets.CI_USER_TOKEN || secrets.GITHUB_TOKEN }}`
+        token: ${{ secrets.CI_USER_TOKEN || secrets.GITHUB_TOKEN }}
         repository: 'optimizely/travisci-tools'
         path: 'home/runner/travisci-tools'
         ref: 'master'

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout branch
       uses: actions/checkout@v3
       with:
-        token: ${{ secrets.CI_USER_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}`
         repository: 'optimizely/travisci-tools'
         path: 'home/runner/travisci-tools'
         ref: 'master'

--- a/src/Provider.spec.tsx
+++ b/src/Provider.spec.tsx
@@ -83,6 +83,8 @@ describe('OptimizelyProvider', () => {
   });
 
   it('should render successfully without user or userId provided', () => {
+    // @ts-ignore
+    mockReactClient.user = undefined;
     render(<OptimizelyProvider optimizely={mockReactClient} />);
 
     expect(mockReactClient.setUser).toHaveBeenCalledWith(DefaultUser);
@@ -95,6 +97,8 @@ describe('OptimizelyProvider', () => {
   });
 
   it('should succeed just userAttributes provided', () => {
+    // @ts-ignore
+    mockReactClient.user = undefined;
     render(<OptimizelyProvider optimizely={mockReactClient} userAttributes={{ attr1: 'value1' }} />);
 
     expect(mockReactClient.setUser).toHaveBeenCalledWith({

--- a/src/Provider.spec.tsx
+++ b/src/Provider.spec.tsx
@@ -107,6 +107,21 @@ describe('OptimizelyProvider', () => {
     });
   });
 
+  it('should succeed with the initial user available in client', () => {
+    render(<OptimizelyProvider optimizely={mockReactClient} />);
+
+    expect(mockReactClient.setUser).toHaveBeenCalledWith(user1);
+  });
+
+  it('should succeed with the initial user id and newly passed attributes', () => {
+    render(<OptimizelyProvider optimizely={mockReactClient} userAttributes={{ attr1: 'value2' }} />);
+
+    expect(mockReactClient.setUser).toHaveBeenCalledWith({
+      id: user1.id,
+      attributes: { attr1: 'value2' },
+    });
+  });
+
   it('should not update when isServerSide is true', () => {
     // Initial render
     const { rerender } = render(<OptimizelyProvider optimizely={mockReactClient} isServerSide={true} user={user1} />);

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -73,6 +73,11 @@ export class OptimizelyProvider extends React.Component<OptimizelyProviderProps,
       };
       // deprecation warning
       logger.warn('Passing userId and userAttributes as props is deprecated, please switch to using `user` prop');
+    } else if (optimizely.user) {
+      finalUser = {
+        id: optimizely.user.id,
+        attributes: optimizely.user.attributes || userAttributes || {},
+      };
     } else {
       finalUser = {
         id: DefaultUser.id,

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -74,9 +74,10 @@ export class OptimizelyProvider extends React.Component<OptimizelyProviderProps,
       // deprecation warning
       logger.warn('Passing userId and userAttributes as props is deprecated, please switch to using `user` prop');
     } else if (optimizely.user) {
+      const { id, attributes } = optimizely.user;
       finalUser = {
-        id: optimizely.user.id,
-        attributes: optimizely.user.attributes || userAttributes || {},
+        id,
+        attributes: userAttributes || attributes || {},
       };
     } else {
       finalUser = {


### PR DESCRIPTION
## Summary
After upgrading to v3 of the Optimizely React SDK, rendering the `OptimizelyProvider` after calling `setUser` resets the user to a default one unless explicitly provided via the user prop.

## Test plan
Existing tests have been adjusted accordingly.

## Issues
- [FSSDK-10880](https://jira.sso.episerver.net/browse/FSSDK-10880)
- #286