### PR TITLE
Remove utility-types dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,10 +537,6 @@ License: [MIT](https://github.com/facebook/react/blob/master/LICENSE)
 Copyright &copy; Facebook, Inc. and its affiliates.
 License: [MIT](https://github.com/facebook/react/blob/master/LICENSE)
 
-[**utility-types**](https://github.com/piotrwitek/utility-types)
-Copyright &copy; 2016 Piotr Witek <piotrek.witek@gmail.com>
-License: [MIT](https://github.com/piotrwitek/utility-types/blob/master/LICENSE)
-
 [**node-uuid**](https://github.com/kelektiv/node-uuid)
 Copyright &copy; 2010-2016 Robert Kieffer and other contributors
 License: [MIT](https://github.com/kelektiv/node-uuid/blob/master/LICENSE.md)

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
   },
   "dependencies": {
     "@optimizely/optimizely-sdk": "^5.3.4",
-    "hoist-non-react-statics": "^3.3.2",
-    "utility-types": "^2.1.0 || ^3.0.0"
+    "hoist-non-react-statics": "^3.3.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/src/withOptimizely.tsx
+++ b/src/withOptimizely.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import * as React from 'react';
-import { Subtract } from 'utility-types';
 
 import { OptimizelyContextConsumer, OptimizelyContextInterface } from './Context';
 import { ReactSDKClient } from './client';
@@ -26,7 +25,7 @@ export interface WithOptimizelyProps {
   isServerSide: boolean;
 }
 
-export type WithoutOptimizelyProps<P extends WithOptimizelyProps> = Subtract<P, WithOptimizelyProps>;
+export type WithoutOptimizelyProps<P extends WithOptimizelyProps> = Omit<P, keyof WithOptimizelyProps>;
 
 export function withOptimizely<P extends WithOptimizelyProps, R>(
   Component: React.ComponentType<P>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4800,11 +4800,6 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-"utility-types@^2.1.0 || ^3.0.0":
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.11.0.tgz#607c40edb4f258915e901ea7995607fdf319424c"
-  integrity sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==
-
 uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"


### PR DESCRIPTION
## Summary
- The `utility-types` dependency has been removed and TypeScript's Omit function used instead.

## Test plan
Existing test should pass

## Issues
- [FSSDK-10881](https://jira.sso.episerver.net/browse/FSSDK-10881)