### PR TITLE
Junaed/fssdk 10980 optimizely onready always returns false

### DIFF
--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -315,6 +315,25 @@ describe('ReactSDKClient', () => {
       expect(instance.getUserContext()).toBe(null);
     });
 
+    it('if user id is not present, and ODP is explicitly off, user promise will be pending', async () => {
+      jest.spyOn(mockInnerClient, 'onReady').mockResolvedValue({ success: true });
+
+      instance = createInstance({
+        ...config,
+        odpOptions: {
+          disabled: true,
+        },
+      });
+
+      await instance.setUser(DefaultUser);
+      expect(instance.isReady()).toBe(false);
+
+      await instance.setUser({ id: 'user123' });
+      await instance.onReady();
+
+      expect(instance.isReady()).toBe(true);
+    });
+
     it('can be called with no/default user set', async () => {
       jest.spyOn(mockOptimizelyUserContext, 'getUserId').mockReturnValue(validVuid);
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -242,7 +242,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     this._client = optimizely.createInstance(configWithClientInfo);
     this.isClientReady = !!this.getOptimizelyConfig();
     this.isUsingSdkKey = !!configWithClientInfo.sdkKey;
-    console.log('I am in the constructor', this.isClientReady, this.isUsingSdkKey);
+
     if (this._client) {
       const clientReadyPromise = this._client.onReady();
 
@@ -250,8 +250,6 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
         ([userResult, clientResult]) => {
           this.isClientReady = clientResult.success;
           this.isUserReady = userResult.success;
-          console.log('isClientReady', this.isClientReady);
-          console.log('isUserReady', this.isUserReady);
           const clientAndUserReady = this.isReady();
           this.clientAndUserReadyPromiseFulfilled = true;
 
@@ -384,7 +382,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
   }
 
   public async setUser(userInfo: UserInfo): Promise<void> {
-    // If user id is not present and ODP is explicitly off, user promise will be pending
+    // If user id is not present and ODP is explicitly off, user promise will be pending until setUser is called again with proper user id
     if (userInfo?.id === null && this.odpExplicitlyOff) {
       return;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -242,7 +242,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     this._client = optimizely.createInstance(configWithClientInfo);
     this.isClientReady = !!this.getOptimizelyConfig();
     this.isUsingSdkKey = !!configWithClientInfo.sdkKey;
-
+    console.log('I am in the constructor', this.isClientReady, this.isUsingSdkKey);
     if (this._client) {
       const clientReadyPromise = this._client.onReady();
 
@@ -250,6 +250,8 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
         ([userResult, clientResult]) => {
           this.isClientReady = clientResult.success;
           this.isUserReady = userResult.success;
+          console.log('isClientReady', this.isClientReady);
+          console.log('isUserReady', this.isUserReady);
           const clientAndUserReady = this.isReady();
           this.clientAndUserReadyPromiseFulfilled = true;
 
@@ -382,6 +384,10 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
   }
 
   public async setUser(userInfo: UserInfo): Promise<void> {
+    // If user id is not present and ODP is explicitly off, user promise will be pending
+    if (userInfo?.id === null && this.odpExplicitlyOff) {
+      return;
+    }
     this.user = {
       id: userInfo.id || DefaultUser.id,
       attributes: userInfo.attributes || DefaultUser.attributes,


### PR DESCRIPTION
## Summary
`optimizelyClient.isReady` always returns `false`  when ODP is explicitly off and user id is null.

Expected behavior - "User promise should not be fulfilled unless a valid user is set, when ODP is disabled".

## Test plan
Test case has been added to cover this edge case

## Issues
- #300 
- [FSSDK-10980](https://jira.sso.episerver.net/browse/FSSDK-10980)