### PR TITLE
Release 3.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.2.4] - May 15, 2025
+### Bug fixes
+- `client.onReady()` always returns false when ODP is off and user id is null bug fix.([#302](https://github.com/optimizely/react-sdk/pull/285))
+
 ## [3.2.3] - Nov 22, 2024
 
 ### Bug fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/react-sdk",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "React SDK for Optimizely Feature Experimentation, Optimizely Full Stack (legacy), and Optimizely Rollouts",
   "homepage": "https://github.com/optimizely/react-sdk",
   "repository": "https://github.com/optimizely/react-sdk",

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -178,7 +178,7 @@ describe('ReactSDKClient', () => {
       expect(createInstanceSpy).toHaveBeenCalledWith({
         ...config,
         clientEngine: 'react-sdk',
-        clientVersion: '3.2.3',
+        clientVersion: '3.2.4',
       });
     });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,7 +47,7 @@ export interface OnReadyResult extends ResolveResult {
 }
 
 const REACT_SDK_CLIENT_ENGINE = 'react-sdk';
-const REACT_SDK_CLIENT_VERSION = '3.2.3';
+const REACT_SDK_CLIENT_VERSION = '3.2.4';
 
 export const DefaultUser: UserInfo = {
   id: null,


### PR DESCRIPTION
## Summary
Relase PR
### Bug fixes
- `client.onReady()` always returns false when ODP is off and user id is null bug fix.([#302](https://github.com/optimizely/react-sdk/pull/285))
## Test plan
Existing test should pass
## Issues
[FSSDK-10730](https://jira.sso.episerver.net/browse/FSSDK-10730)