### PR TITLE
[FSSDK-12294] hook fix

### DIFF
--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -22,10 +22,10 @@ export interface UseDecideConfig {
 
 export type UseDecideResult =
   | { isLoading: true; error: null; decision: null }
-  | { isLoading: false; error: Error; decision: null }
+  | { isLoading: false; error: Error; decision: OptimizelyDecision | null }
   | { isLoading: false; error: null; decision: OptimizelyDecision };
 
 export type UseDecideMultiResult =
   | { isLoading: true; error: null; decisions: Record<string, never> }
-  | { isLoading: false; error: Error; decisions: Record<string, never> }
+  | { isLoading: false; error: Error; decisions: Record<string, OptimizelyDecision> }
   | { isLoading: false; error: null; decisions: Record<string, OptimizelyDecision> };

--- a/src/hooks/useAsyncDecision.ts
+++ b/src/hooks/useAsyncDecision.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { OptimizelyUserContext } from '@optimizely/optimizely-sdk';
 
 import type { Client } from '@optimizely/optimizely-sdk';
@@ -52,6 +52,8 @@ export function useAsyncDecision<TResult>(
     isLoading: true,
   });
 
+  const prevUserContextRef = useRef<OptimizelyUserContext | null>(null);
+
   useEffect(() => {
     const { userContext, error } = state;
     const hasConfig = client.getOptimizelyConfig() !== null;
@@ -69,10 +71,12 @@ export function useAsyncDecision<TResult>(
       return;
     }
 
-    // Ensure loading state (skip if already loading to avoid re-render)
+    const userContextChanged = userContext !== prevUserContextRef.current;
+    prevUserContextRef.current = userContext;
+
     setAsyncState((prev) => {
       if (prev.isLoading) return prev;
-      return { result: emptyResult, error: null, isLoading: true };
+      return { result: userContextChanged ? emptyResult : prev.result, error: null, isLoading: true };
     });
 
     // Config + userContext available — fire async decision even if store has error

--- a/src/hooks/useAsyncDecision.ts
+++ b/src/hooks/useAsyncDecision.ts
@@ -56,9 +56,16 @@ export function useAsyncDecision<TResult>(
     const { userContext, error } = state;
     const hasConfig = client.getOptimizelyConfig() !== null;
 
-    // Store-level error — no async call needed
-    if (error) {
-      setAsyncState({ result: emptyResult, error, isLoading: false });
+    // No decision possible — surface store error or stay loading
+    if (!hasConfig || userContext === null) {
+      if (error) {
+        setAsyncState({ result: emptyResult, error, isLoading: false });
+      } else {
+        setAsyncState((prev) => {
+          if (prev.isLoading) return prev;
+          return { result: emptyResult, error: null, isLoading: true };
+        });
+      }
       return;
     }
 
@@ -68,18 +75,13 @@ export function useAsyncDecision<TResult>(
       return { result: emptyResult, error: null, isLoading: true };
     });
 
-    // Store not ready — wait for config/user context
-    if (!hasConfig || userContext === null) {
-      return;
-    }
-
-    // Store is ready — fire async decision
+    // Config + userContext available — fire async decision even if store has error
     let cancelled = false;
 
     execute(userContext).then(
       (result) => {
         if (!cancelled) {
-          setAsyncState({ result, error: null, isLoading: false });
+          setAsyncState({ result, error, isLoading: false });
         }
       },
       (err) => {

--- a/src/hooks/useDecide.spec.tsx
+++ b/src/hooks/useDecide.spec.tsx
@@ -129,7 +129,7 @@ describe('useDecide', () => {
     expect(result.current.decision).toBe(MOCK_DECISION);
   });
 
-  it('should return error from store with isLoading: false', async () => {
+  it('should return error from store with isLoading: false when no decision is possible', async () => {
     const wrapper = createWrapper(store, mockClient);
     const { result } = renderHook(() => useDecide('flag_1'), { wrapper });
 
@@ -143,6 +143,28 @@ describe('useDecide', () => {
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBe(testError);
     expect(result.current.decision).toBeNull();
+  });
+
+  it('should return stale decision alongside error when config and user context are available', async () => {
+    mockClient = createMockClient(true);
+    const mockUserContext = createMockUserContext();
+    store.setUserContext(mockUserContext);
+
+    const wrapper = createWrapper(store, mockClient);
+    const { result } = renderHook(() => useDecide('flag_1'), { wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.decision).toBe(MOCK_DECISION);
+    expect(result.current.error).toBeNull();
+
+    const testError = new Error('CDN datafile fetch failed');
+    await act(async () => {
+      store.setError(testError);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(testError);
+    expect(result.current.decision).toBe(MOCK_DECISION);
   });
 
   it('should re-evaluate when flagKey changes', () => {

--- a/src/hooks/useDecide.ts
+++ b/src/hooks/useDecide.ts
@@ -52,15 +52,15 @@ export function useDecide(flagKey: string, config?: UseDecideConfig): UseDecideR
     const { userContext, error } = state;
     const hasConfig = client.getOptimizelyConfig() !== null;
 
+    if (hasConfig && userContext !== null) {
+      const decision = userContext.decide(flagKey, decideOptions);
+      return { decision, isLoading: false, error };
+    }
+
     if (error) {
       return { decision: null, isLoading: false, error };
     }
 
-    if (!hasConfig || userContext === null) {
-      return { decision: null, isLoading: true, error: null };
-    }
-
-    const decision = userContext.decide(flagKey, decideOptions);
-    return { decision, isLoading: false, error: null };
+    return { decision: null, isLoading: true, error: null };
   }, [fdVersion, state, client, flagKey, decideOptions]);
 }

--- a/src/hooks/useDecideAll.spec.tsx
+++ b/src/hooks/useDecideAll.spec.tsx
@@ -112,7 +112,7 @@ describe('useDecideAll', () => {
     expect(mockUserContext.decideAll).toHaveBeenCalledWith(decideOptions);
   });
 
-  it('should return error from store with isLoading: false', async () => {
+  it('should return error from store with isLoading: false when no decision is possible', async () => {
     const wrapper = createWrapper(store, mockClient);
     const { result } = renderHook(() => useDecideAll(), { wrapper });
 
@@ -126,6 +126,28 @@ describe('useDecideAll', () => {
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBe(testError);
     expect(result.current.decisions).toEqual({});
+  });
+
+  it('should return stale decisions alongside error when config and user context are available', async () => {
+    mockClient = createMockClient(true);
+    const mockUserContext = createMockUserContext();
+    store.setUserContext(mockUserContext);
+
+    const wrapper = createWrapper(store, mockClient);
+    const { result } = renderHook(() => useDecideAll(), { wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.decisions).toEqual(MOCK_DECISIONS);
+    expect(result.current.error).toBeNull();
+
+    const testError = new Error('CDN datafile fetch failed');
+    await act(async () => {
+      store.setError(testError);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(testError);
+    expect(result.current.decisions).toEqual(MOCK_DECISIONS);
   });
 
   it('should not call decideAll() while loading', () => {

--- a/src/hooks/useDecideAll.ts
+++ b/src/hooks/useDecideAll.ts
@@ -15,6 +15,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
+import type { OptimizelyDecision } from '@optimizely/optimizely-sdk';
 
 import { useOptimizelyContext } from './useOptimizelyContext';
 import { useProviderState } from './useProviderState';
@@ -47,15 +48,15 @@ export function useDecideAll(config?: UseDecideConfig): UseDecideMultiResult {
     const { userContext, error } = state;
     const hasConfig = client.getOptimizelyConfig() !== null;
 
+    if (hasConfig && userContext !== null) {
+      const decisions = userContext.decideAll(decideOptions);
+      return { decisions, isLoading: false as const, error };
+    }
+
     if (error) {
-      return { decisions: {} as Record<string, never>, isLoading: false as const, error };
+      return { decisions: {} as Record<string, OptimizelyDecision>, isLoading: false as const, error };
     }
 
-    if (!hasConfig || userContext === null) {
-      return { decisions: {} as Record<string, never>, isLoading: true as const, error: null };
-    }
-
-    const decisions = userContext.decideAll(decideOptions);
-    return { decisions, isLoading: false as const, error: null };
+    return { decisions: {} as Record<string, never>, isLoading: true as const, error: null };
   }, [fdVersion, state, client, decideOptions]);
 }

--- a/src/hooks/useDecideAllAsync.spec.tsx
+++ b/src/hooks/useDecideAllAsync.spec.tsx
@@ -68,7 +68,7 @@ describe('useDecideAllAsync', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('should return error from store with isLoading: false', async () => {
+  it('should return error from store with isLoading: false when no decision is possible', async () => {
     const wrapper = createWrapper(store, mockClient);
     const { result } = renderHook(() => useDecideAllAsync(), { wrapper });
 
@@ -82,6 +82,34 @@ describe('useDecideAllAsync', () => {
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBe(testError);
     expect(result.current.decisions).toEqual({});
+  });
+
+  it('should return stale decisions alongside error when config and user context are available', async () => {
+    mockClient = createMockClient(true);
+    const mockUserContext = createMockUserContext();
+    store.setUserContext(mockUserContext);
+
+    const wrapper = createWrapper(store, mockClient);
+    const { result } = renderHook(() => useDecideAllAsync(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.decisions).toEqual(MOCK_DECISIONS);
+    expect(result.current.error).toBeNull();
+
+    const testError = new Error('CDN datafile fetch failed');
+    await act(async () => {
+      store.setError(testError);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe(testError);
+    expect(result.current.decisions).toEqual(MOCK_DECISIONS);
   });
 
   it('should return isLoading: true while async call is in-flight', () => {

--- a/src/hooks/useDecideAsync.spec.tsx
+++ b/src/hooks/useDecideAsync.spec.tsx
@@ -68,7 +68,7 @@ describe('useDecideAsync', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('should return error from store with isLoading: false', async () => {
+  it('should return error from store with isLoading: false when no decision is possible', async () => {
     const wrapper = createWrapper(store, mockClient);
     const { result } = renderHook(() => useDecideAsync('flag_1'), { wrapper });
 
@@ -82,6 +82,34 @@ describe('useDecideAsync', () => {
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBe(testError);
     expect(result.current.decision).toBeNull();
+  });
+
+  it('should return stale decision alongside error when config and user context are available', async () => {
+    mockClient = createMockClient(true);
+    const mockUserContext = createMockUserContext();
+    store.setUserContext(mockUserContext);
+
+    const wrapper = createWrapper(store, mockClient);
+    const { result } = renderHook(() => useDecideAsync('flag_1'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.decision).toBe(MOCK_DECISION);
+    expect(result.current.error).toBeNull();
+
+    const testError = new Error('CDN datafile fetch failed');
+    await act(async () => {
+      store.setError(testError);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe(testError);
+    expect(result.current.decision).toBe(MOCK_DECISION);
   });
 
   it('should return isLoading: true while async call is in-flight', () => {

--- a/src/hooks/useDecideAsync.spec.tsx
+++ b/src/hooks/useDecideAsync.spec.tsx
@@ -112,6 +112,32 @@ describe('useDecideAsync', () => {
     expect(result.current.decision).toBe(MOCK_DECISION);
   });
 
+  it('should preserve previous decision during re-execute when only store error changes', async () => {
+    mockClient = createMockClient(true);
+    const mockUserContext = createMockUserContext();
+    store.setUserContext(mockUserContext);
+
+    const wrapper = createWrapper(store, mockClient);
+    const { result } = renderHook(() => useDecideAsync('flag_1'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.decision).toBe(MOCK_DECISION);
+
+    // Make next async call hang so we can observe intermediate state
+    (mockUserContext.decideAsync as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+
+    const testError = new Error('CDN refresh failed');
+    await act(async () => {
+      store.setError(testError);
+    });
+
+    // Should be loading but still have the previous decision, not null
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.decision).toBe(MOCK_DECISION);
+  });
+
   it('should return isLoading: true while async call is in-flight', () => {
     mockClient = createMockClient(true);
     const mockUserContext = createMockUserContext();

--- a/src/hooks/useDecideForKeys.spec.tsx
+++ b/src/hooks/useDecideForKeys.spec.tsx
@@ -112,7 +112,7 @@ describe('useDecideForKeys', () => {
     expect(mockUserContext.decideForKeys).toHaveBeenCalledWith(['flag_1'], decideOptions);
   });
 
-  it('should return error from store with isLoading: false', async () => {
+  it('should return error from store with isLoading: false when no decision is possible', async () => {
     const wrapper = createWrapper(store, mockClient);
     const { result } = renderHook(() => useDecideForKeys(['flag_1']), { wrapper });
 
@@ -126,6 +126,28 @@ describe('useDecideForKeys', () => {
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBe(testError);
     expect(result.current.decisions).toEqual({});
+  });
+
+  it('should return stale decisions alongside error when config and user context are available', async () => {
+    mockClient = createMockClient(true);
+    const mockUserContext = createMockUserContext();
+    store.setUserContext(mockUserContext);
+
+    const wrapper = createWrapper(store, mockClient);
+    const { result } = renderHook(() => useDecideForKeys(['flag_1', 'flag_2']), { wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.decisions).toEqual(MOCK_DECISIONS);
+    expect(result.current.error).toBeNull();
+
+    const testError = new Error('CDN datafile fetch failed');
+    await act(async () => {
+      store.setError(testError);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(testError);
+    expect(result.current.decisions).toEqual(MOCK_DECISIONS);
   });
 
   it('should not call decideForKeys() while loading', () => {

--- a/src/hooks/useDecideForKeys.ts
+++ b/src/hooks/useDecideForKeys.ts
@@ -15,6 +15,8 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
+import type { OptimizelyDecision } from '@optimizely/optimizely-sdk';
+
 import { useOptimizelyContext } from './useOptimizelyContext';
 import { useProviderState } from './useProviderState';
 import { useStableArray } from './useStableArray';
@@ -50,15 +52,15 @@ export function useDecideForKeys(flagKeys: string[], config?: UseDecideConfig): 
     const { userContext, error } = state;
     const hasConfig = client.getOptimizelyConfig() !== null;
 
+    if (hasConfig && userContext !== null) {
+      const decisions = userContext.decideForKeys(stableKeys, decideOptions);
+      return { decisions, isLoading: false as const, error };
+    }
+
     if (error) {
-      return { decisions: {}, isLoading: false, error };
+      return { decisions: {} as Record<string, OptimizelyDecision>, isLoading: false as const, error };
     }
 
-    if (!hasConfig || userContext === null) {
-      return { decisions: {}, isLoading: true, error: null };
-    }
-
-    const decisions = userContext.decideForKeys(stableKeys, decideOptions);
-    return { decisions, isLoading: false as const, error: null };
+    return { decisions: {} as Record<string, never>, isLoading: true as const, error: null };
   }, [fdVersion, state, client, stableKeys, decideOptions]);
 }

--- a/src/hooks/useDecideForKeysAsync.spec.tsx
+++ b/src/hooks/useDecideForKeysAsync.spec.tsx
@@ -68,7 +68,7 @@ describe('useDecideForKeysAsync', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('should return error from store with isLoading: false', async () => {
+  it('should return error from store with isLoading: false when no decision is possible', async () => {
     const wrapper = createWrapper(store, mockClient);
     const { result } = renderHook(() => useDecideForKeysAsync(['flag_1']), { wrapper });
 
@@ -82,6 +82,34 @@ describe('useDecideForKeysAsync', () => {
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBe(testError);
     expect(result.current.decisions).toEqual({});
+  });
+
+  it('should return stale decisions alongside error when config and user context are available', async () => {
+    mockClient = createMockClient(true);
+    const mockUserContext = createMockUserContext();
+    store.setUserContext(mockUserContext);
+
+    const wrapper = createWrapper(store, mockClient);
+    const { result } = renderHook(() => useDecideForKeysAsync(['flag_1', 'flag_2']), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.decisions).toEqual(MOCK_DECISIONS);
+    expect(result.current.error).toBeNull();
+
+    const testError = new Error('CDN datafile fetch failed');
+    await act(async () => {
+      store.setError(testError);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe(testError);
+    expect(result.current.decisions).toEqual(MOCK_DECISIONS);
   });
 
   it('should return isLoading: true while async call is in-flight', () => {

--- a/src/hooks/useOptimizelyUserContext.spec.tsx
+++ b/src/hooks/useOptimizelyUserContext.spec.tsx
@@ -150,7 +150,7 @@ describe('useOptimizelyUserContext', () => {
     expect(result.current.userContext).toBeNull();
   });
 
-  it('should return error with isLoading: false when store has error', async () => {
+  it('should return error with isLoading: false when store has error and no user context', async () => {
     const wrapper = createWrapper(store);
     const { result } = renderHook(() => useOptimizelyUserContext(), { wrapper });
 
@@ -164,6 +164,27 @@ describe('useOptimizelyUserContext', () => {
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBe(testError);
     expect(result.current.userContext).toBeNull();
+  });
+
+  it('should return stale user context alongside error when user context was already set', async () => {
+    const mockUserContext = createMockUserContext();
+    store.setUserContext(mockUserContext);
+
+    const wrapper = createWrapper(store);
+    const { result } = renderHook(() => useOptimizelyUserContext(), { wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.userContext).toBe(mockUserContext);
+    expect(result.current.error).toBeNull();
+
+    const testError = new Error('CDN datafile fetch failed');
+    await act(async () => {
+      store.setError(testError);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(testError);
+    expect(result.current.userContext).toBe(mockUserContext);
   });
 
   it('should unsubscribe from store on unmount', () => {

--- a/src/hooks/useOptimizelyUserContext.ts
+++ b/src/hooks/useOptimizelyUserContext.ts
@@ -22,7 +22,7 @@ import { useOptimizelyContext } from './useOptimizelyContext';
 
 export type UseOptimizelyUserContextResult =
   | { isLoading: true; error: null; userContext: null }
-  | { isLoading: false; error: Error; userContext: null }
+  | { isLoading: false; error: Error; userContext: OptimizelyUserContext | null }
   | { isLoading: false; error: null; userContext: OptimizelyUserContext };
 
 /**
@@ -42,14 +42,14 @@ export function useOptimizelyUserContext(): UseOptimizelyUserContextResult {
   return useMemo(() => {
     const { userContext, error } = state;
 
+    if (userContext !== null) {
+      return { userContext, isLoading: false, error };
+    }
+
     if (error) {
       return { userContext: null, isLoading: false, error };
     }
 
-    if (userContext === null) {
-      return { userContext: null, isLoading: true, error: null };
-    }
-
-    return { userContext, isLoading: false, error: null };
+    return { userContext: null, isLoading: true, error: null };
   }, [state]);
 }


### PR DESCRIPTION
## Summary
- Implement stale-while-error pattern across all hooks: when a store-level error occurs (e.g., CDN datafile fetch failure) but a valid config and user context already exist, hooks now return the existing decision/userContext alongside the error instead of nulling them out. Previously, if `onReady()` rejected after a sync datafile was already loaded, all hooks immediately returned `{ decision: null, error }` — discarding a perfectly usable datafile. This was overly aggressive for the common case where a sync datafile is provided and a background CDN refresh fails due to network issues.

## Test plan
Tests have been added to address the change.
## Issues
- FSSDK-12294
