### PR TITLE
chore: Version bump of @optimizely/optimizely-sdk 

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "src/**/*.{js,ts,tsx}": "eslint --fix"
   },
   "dependencies": {
-    "@optimizely/optimizely-sdk": "^6.4.0",
+    "@optimizely/optimizely-sdk": "^6.5.0",
     "tslib": "^2.8.1",
     "use-sync-external-store": "^1.6.0"
   },


### PR DESCRIPTION
Version bump of @optimizely/optimizely-sdk to address vulnerability in downstream dependency. See:

- https://github.com/optimizely/javascript-sdk/releases/tag/v6.5.0

Existing tests should pass

- FIXES: #340