### PR TITLE
[FSSDK-12882] release pipeline update

### DIFF
--- a/.github/workflows/ghr_backfill.yml
+++ b/.github/workflows/ghr_backfill.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Single version to backfill (e.g. 4.0.0). Leave blank to backfill all missing versions."
+        description: "Single version to backfill (e.g. 4.0.0). Leave blank to process all published npm versions (versions already on GHR are skipped)."
         required: false
         default: ""
       dry_run:
@@ -37,20 +37,15 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 18
-        registry-url: "https://registry.npmjs.org/"
-        always-auth: "true"
 
-    # Add GHR auth for publishing. npm expands ${NODE_AUTH_TOKEN} at runtime, and
-    # scripts/publish.sh passes --registry explicitly, so the default registry
-    # stays on npm (backfill reads tarballs from npm, writes them to GHR).
     - name: Configure GHR auth
       run: echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" >> ~/.npmrc
 
     - name: Backfill
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        DRY_RUN: ${{ github.event.inputs.dry_run }}
-        INPUT_VERSION: ${{ github.event.inputs.version }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        INPUT_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
         pkg="@optimizely/react-sdk"

--- a/.github/workflows/ghr_backfill.yml
+++ b/.github/workflows/ghr_backfill.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
     - name: Checkout branch
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Set up Node
       uses: actions/setup-node@v4
@@ -48,12 +50,13 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DRY_RUN: ${{ github.event.inputs.dry_run }}
+        INPUT_VERSION: ${{ github.event.inputs.version }}
       run: |
         set -euo pipefail
         pkg="@optimizely/react-sdk"
 
-        if [[ -n "${{ github.event.inputs.version }}" ]]; then
-          versions="${{ github.event.inputs.version }}"
+        if [[ -n "$INPUT_VERSION" ]]; then
+          versions="$INPUT_VERSION"
         else
           versions=$(npm view "$pkg" versions --json --registry https://registry.npmjs.org | jq -r '.[]')
         fi

--- a/.github/workflows/ghr_backfill.yml
+++ b/.github/workflows/ghr_backfill.yml
@@ -1,0 +1,67 @@
+name: Backfill GitHub Package Registry
+
+# Manually triggered. Copies versions already published on npm into the GitHub
+# Package Registry so GHR mirrors npm. Re-publishing the npm tarball guarantees
+# the GHR copy is byte-identical to what npm consumers received (no rebuild).
+#
+# Idempotent: scripts/publish.sh skips any version already present on GHR, so
+# this can be re-run safely.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Single version to backfill (e.g. 4.0.0). Leave blank to backfill all missing versions."
+        required: false
+        default: ""
+      dry_run:
+        description: "Dry run: report what would be published to GHR without publishing."
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  backfill:
+    name: Backfill npm versions to GHR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v4
+
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18
+        registry-url: "https://registry.npmjs.org/"
+        always-auth: "true"
+
+    # Add GHR auth for publishing. npm expands ${NODE_AUTH_TOKEN} at runtime, and
+    # scripts/publish.sh passes --registry explicitly, so the default registry
+    # stays on npm (backfill reads tarballs from npm, writes them to GHR).
+    - name: Configure GHR auth
+      run: echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" >> ~/.npmrc
+
+    - name: Backfill
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DRY_RUN: ${{ github.event.inputs.dry_run }}
+      run: |
+        set -euo pipefail
+        pkg="@optimizely/react-sdk"
+
+        if [[ -n "${{ github.event.inputs.version }}" ]]; then
+          versions="${{ github.event.inputs.version }}"
+        else
+          versions=$(npm view "$pkg" versions --json --registry https://registry.npmjs.org | jq -r '.[]')
+        fi
+
+        for v in $versions; do
+          echo "::group::${pkg}@${v}"
+          tarball=$(npm pack "${pkg}@${v}" --registry https://registry.npmjs.org 2>/dev/null | tail -n1)
+          scripts/publish.sh "https://npm.pkg.github.com" "$tarball"
+          rm -f "$tarball"
+          echo "::endgroup::"
+        done

--- a/.github/workflows/ghr_backfill.yml
+++ b/.github/workflows/ghr_backfill.yml
@@ -63,7 +63,10 @@ jobs:
 
         for v in $versions; do
           echo "::group::${pkg}@${v}"
-          tarball=$(npm pack "${pkg}@${v}" --registry https://registry.npmjs.org 2>/dev/null | tail -n1)
+          # npm pack writes the tarball filename to stdout and notices/errors to
+          # stderr; keep stderr visible so pack failures (auth/404/network) show
+          # in the logs. pipefail (set above) makes a failed pack abort the job.
+          tarball=$(npm pack "${pkg}@${v}" --registry https://registry.npmjs.org | tail -n1)
           scripts/publish.sh "https://npm.pkg.github.com" "$tarball"
           rm -f "$tarball"
           echo "::endgroup::"

--- a/.github/workflows/react_release.yml
+++ b/.github/workflows/react_release.yml
@@ -1,11 +1,11 @@
-name: Publish React SDK to NPM
+name: Publish React SDK
 
 on:
   release:
     types: [ published ]
 
 jobs:
-  publish:
+  publish-npm:
     name: Publish to NPM
     runs-on: ubuntu-latest
     steps:
@@ -19,27 +19,47 @@ jobs:
         registry-url: "https://registry.npmjs.org/"
         always-auth: "true"
         cache: 'npm'
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_REACT_TO_NPM_FROM_GITHUB }}
 
     - name: Install dependencies
       run: npm ci
 
-    - id: npm-tag
-      name: Determine NPM tag
-      run: |
-        version=$(jq -r '.version' package.json)
-        if [[ "$version" == *"-beta"* ]]; then
-          echo "npm-tag=beta" >> "$GITHUB_OUTPUT"
-        elif [[ "$version" == *"-alpha"* ]]; then
-          echo "npm-tag=alpha" >> "$GITHUB_OUTPUT"
-        elif [[ "$version" == *"-rc"* ]]; then
-          echo "npm-tag=rc" >> "$GITHUB_OUTPUT"
-        else
-          echo "npm-tag=latest" >> "$GITHUB_OUTPUT"
-        fi
-
-    - name: Test, build, then publish
+    - name: Publish to NPM
       env:
         NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_REACT_TO_NPM_FROM_GITHUB }}
-      run: npm publish --tag ${{ steps.npm-tag.outputs['npm-tag'] }}
+      run: scripts/publish.sh "https://registry.npmjs.org"
+
+  publish-ghr:
+    name: Publish to GitHub Package Registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v4
+
+    # Install from the public npm registry so scoped dependencies
+    # (e.g. @optimizely/optimizely-sdk) resolve normally. We do NOT route the
+    # @optimizely scope to GHR here, otherwise `npm ci` would look for
+    # dependencies on GHR instead of npm.
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18
+        registry-url: "https://registry.npmjs.org/"
+        always-auth: "true"
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    # Add GHR auth for the publish only. npm expands ${NODE_AUTH_TOKEN} at
+    # runtime, and scripts/publish.sh passes --registry explicitly, so the
+    # default registry stays on npm.
+    - name: Configure GHR auth
+      run: echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" >> ~/.npmrc
+
+    - name: Publish to GHR
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: scripts/publish.sh "https://npm.pkg.github.com"

--- a/.github/workflows/react_release.yml
+++ b/.github/workflows/react_release.yml
@@ -17,9 +17,6 @@ jobs:
       with:
         persist-credentials: false
 
-    # Install/build against the public npm registry so scoped dependencies
-    # (e.g. @optimizely/optimizely-sdk) resolve from npm. We do NOT route the
-    # @optimizely scope to GHR; scripts/publish.sh passes --registry explicitly.
     - name: Set up Node
       uses: actions/setup-node@v4
       with:
@@ -28,17 +25,12 @@ jobs:
         always-auth: "true"
         cache: 'npm'
 
-    # Add GHR auth for the GHR publish. npm expands ${NODE_AUTH_TOKEN} at runtime
-    # per-step, so each publish uses the right token for its registry.
     - name: Configure GHR auth
       run: echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" >> ~/.npmrc
 
-    # Deps only; we build explicitly below so the package is built exactly once.
     - name: Install dependencies
       run: npm ci --ignore-scripts
 
-    # Test, build, and pack a single tarball. Both registries publish this same
-    # artifact, guaranteeing npm and GHR receive byte-identical bytes.
     - name: Test, build, and pack
       id: pack
       run: |

--- a/.github/workflows/react_release.yml
+++ b/.github/workflows/react_release.yml
@@ -5,33 +5,8 @@ on:
     types: [ published ]
 
 jobs:
-  publish-npm:
-    name: Publish to NPM
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout branch
-      uses: actions/checkout@v4
-      with:
-        persist-credentials: false
-
-    - name: Set up Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: 18
-        registry-url: "https://registry.npmjs.org/"
-        always-auth: "true"
-        cache: 'npm'
-
-    - name: Install dependencies
-      run: npm ci
-
-    - name: Publish to NPM
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_REACT_TO_NPM_FROM_GITHUB }}
-      run: scripts/publish.sh "https://registry.npmjs.org"
-
-  publish-ghr:
-    name: Publish to GitHub Package Registry
+  publish:
+    name: Publish to NPM and GitHub Package Registry
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,10 +17,9 @@ jobs:
       with:
         persist-credentials: false
 
-    # Install from the public npm registry so scoped dependencies
-    # (e.g. @optimizely/optimizely-sdk) resolve normally. We do NOT route the
-    # @optimizely scope to GHR here, otherwise `npm ci` would look for
-    # dependencies on GHR instead of npm.
+    # Install/build against the public npm registry so scoped dependencies
+    # (e.g. @optimizely/optimizely-sdk) resolve from npm. We do NOT route the
+    # @optimizely scope to GHR; scripts/publish.sh passes --registry explicitly.
     - name: Set up Node
       uses: actions/setup-node@v4
       with:
@@ -54,16 +28,33 @@ jobs:
         always-auth: "true"
         cache: 'npm'
 
-    - name: Install dependencies
-      run: npm ci
-
-    # Add GHR auth for the publish only. npm expands ${NODE_AUTH_TOKEN} at
-    # runtime, and scripts/publish.sh passes --registry explicitly, so the
-    # default registry stays on npm.
+    # Add GHR auth for the GHR publish. npm expands ${NODE_AUTH_TOKEN} at runtime
+    # per-step, so each publish uses the right token for its registry.
     - name: Configure GHR auth
       run: echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" >> ~/.npmrc
 
-    - name: Publish to GHR
+    # Deps only; we build explicitly below so the package is built exactly once.
+    - name: Install dependencies
+      run: npm ci --ignore-scripts
+
+    # Test, build, and pack a single tarball. Both registries publish this same
+    # artifact, guaranteeing npm and GHR receive byte-identical bytes.
+    - name: Test, build, and pack
+      id: pack
+      run: |
+        npm run test
+        npm run build
+        tarball=$(npm pack --ignore-scripts | tail -n1)
+        echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+
+    - name: Publish to NPM
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_REACT_TO_NPM_FROM_GITHUB }}
+        TARBALL: ${{ steps.pack.outputs.tarball }}
+      run: scripts/publish.sh "https://registry.npmjs.org" "$TARBALL"
+
+    - name: Publish to GitHub Package Registry
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: scripts/publish.sh "https://npm.pkg.github.com"
+        TARBALL: ${{ steps.pack.outputs.tarball }}
+      run: scripts/publish.sh "https://npm.pkg.github.com" "$TARBALL"

--- a/.github/workflows/react_release.yml
+++ b/.github/workflows/react_release.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
     - name: Checkout branch
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     # Install from the public npm registry so scoped dependencies
     # (e.g. @optimizely/optimizely-sdk) resolve normally. We do NOT route the

--- a/.github/workflows/react_release.yml
+++ b/.github/workflows/react_release.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - name: Checkout branch
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Set up Node
       uses: actions/setup-node@v4

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -12,24 +12,33 @@
 #                 of the current working directory (used by the GHR backfill).
 #
 # Env:
-#   NODE_AUTH_TOKEN  Auth token for the target registry. The caller must have an
-#                    .npmrc entry supplying auth for <registry-url>'s host, e.g.
-#                    `//<host>/:_authToken=${NODE_AUTH_TOKEN}` (setup-node writes
-#                    this). This script passes --registry explicitly, so no
-#                    scope-to-registry routing is required (and the GHR job
-#                    intentionally does NOT route @optimizely to GHR, so that
-#                    `npm ci` still installs dependencies from npm).
+#   NODE_AUTH_TOKEN  Auth token for the target registry. Used both to read the
+#                    registry (existence/dist-tag lookup) and, via the caller's
+#                    .npmrc entry (`//<host>/:_authToken=${NODE_AUTH_TOKEN}`,
+#                    which setup-node writes), to publish. This script passes
+#                    --registry explicitly, so no scope-to-registry routing is
+#                    required (and the GHR job intentionally does NOT route
+#                    @optimizely to GHR, so that `npm ci` still installs
+#                    dependencies from npm).
 #   DRY_RUN          When "true", report what would happen (publish vs. skip)
 #                    without actually publishing.
 #
 # Behavior:
-#   - Skips (exit 0) if the version already exists on the target registry, so
-#     re-running a release or the backfill is always a safe no-op.
-#   - Computes the dist-tag from the version string (beta/alpha/rc/latest) so a
-#     pre-release never moves the `latest` pointer.
-#   - For a stable release whose major is older than the registry's current
-#     `latest` (e.g. a 5.x patch shipped after 6.x), tags it `v<major>-latest`
-#     instead of `latest`, so `latest` never moves backwards onto an old major.
+#   - Reads the target registry's packument once (a single HTTP GET) and:
+#       * 200 -> package exists; skip (exit 0) if this exact version is already
+#         present, so re-running a release or the backfill is a safe no-op.
+#       * 404 -> package/version absent; proceed to publish.
+#       * any other status or a network failure -> abort (exit 1) rather than
+#         guess. A flaky lookup must never be misread as "not published" and
+#         trigger a publish.
+#   - Computes the dist-tag from the version:
+#       * pre-releases (beta/alpha/rc) get their own tag, never `latest`.
+#       * a stable release gets `latest` ONLY when it is strictly greater (by
+#         semver) than the registry's current `latest`. Otherwise it is tagged
+#         `v<major>.<minor>-latest` (its own release line), so `latest` never
+#         moves backwards onto an older release — this covers both an older
+#         major (5.x shipped after 6.x) and an older minor of the current major
+#         (6.4.1 shipped while latest is 6.5.0).
 set -euo pipefail
 
 dry_run="${DRY_RUN:-false}"
@@ -48,31 +57,76 @@ else
   version=$(jq -r '.version' package.json)
 fi
 
+# Returns 0 if $1 is strictly greater than $2 (numeric major.minor.patch). Only
+# called for stable versions, so no pre-release precedence handling is needed.
+version_gt() {
+  local -a a b
+  local i x y
+  IFS=. read -ra a <<< "$1"
+  IFS=. read -ra b <<< "$2"
+  for i in 0 1 2; do
+    x=${a[i]:-0}
+    y=${b[i]:-0}
+    (( 10#$x > 10#$y )) && return 0
+    (( 10#$x < 10#$y )) && return 1
+  done
+  return 1
+}
+
+# --- Existence / current-latest lookup (single packument GET) ----------------
+# npm scoped names are URL-encoded with the slash as %2f: @scope/name.
+pkg_encoded="${pkg//\//%2f}"
+packument_url="${registry%/}/${pkg_encoded}"
+
+body_file=$(mktemp)
+trap 'rm -f "$body_file"' EXIT
+
+# curl -sS (no --fail) returns 0 for any HTTP response, non-zero only on
+# network/protocol errors — so we can cleanly separate "server answered" from
+# "could not reach server".
+if ! http_code=$(curl -sS -m 30 -o "$body_file" -w '%{http_code}' \
+      -H "Authorization: Bearer ${NODE_AUTH_TOKEN:-}" "$packument_url"); then
+  echo "ERROR: request to ${packument_url} failed (network/timeout); refusing to publish on an ambiguous result." >&2
+  exit 1
+fi
+
+current_latest=""
+case "$http_code" in
+  200)
+    if jq -e --arg v "$version" '.versions[$v] != null' "$body_file" >/dev/null 2>&1; then
+      echo "Version ${pkg}@${version} already on ${registry}, skipping."
+      exit 0
+    fi
+    current_latest=$(jq -r '.["dist-tags"].latest // empty' "$body_file")
+    ;;
+  404)
+    # Package (or this version) not published yet; nothing to compare against.
+    current_latest=""
+    ;;
+  *)
+    echo "ERROR: unexpected HTTP ${http_code} querying ${packument_url}; refusing to publish on an ambiguous result." >&2
+    exit 1
+    ;;
+esac
+
+# --- dist-tag selection ------------------------------------------------------
 case "$version" in
   *-beta*)  tag=beta ;;
   *-alpha*) tag=alpha ;;
   *-rc*)    tag=rc ;;
-  *)        tag=latest ;;
+  *)
+    # Stable release: `latest` only if strictly greater than the current latest.
+    if [[ -z "$current_latest" ]] || version_gt "$version" "$current_latest"; then
+      tag=latest
+    else
+      major=${version%%.*}
+      rest=${version#*.}
+      minor=${rest%%.*}
+      tag="v${major}.${minor}-latest"
+      echo "Current latest is ${current_latest}; ${version} is not newer, tagging as ${tag} to preserve latest."
+    fi
+    ;;
 esac
-
-if npm view "${pkg}@${version}" version --registry "$registry" >/dev/null 2>&1; then
-  echo "Version ${pkg}@${version} already on ${registry}, skipping."
-  exit 0
-fi
-
-# Don't let a stable release move `latest` backwards onto an older major. If the
-# registry's current `latest` is already a newer major than this version, publish
-# under `v<major>-latest` instead. (Only reached when actually publishing, so the
-# extra lookup is skipped for no-op re-runs above.)
-if [[ "$tag" == "latest" ]]; then
-  current_latest=$(npm view "${pkg}" version --registry "$registry" 2>/dev/null || true)
-  our_major=${version%%.*}
-  latest_major=${current_latest%%.*}
-  if [[ "$our_major" =~ ^[0-9]+$ && "$latest_major" =~ ^[0-9]+$ ]] && (( our_major < latest_major )); then
-    tag="v${our_major}-latest"
-    echo "Current latest is ${current_latest} (major ${latest_major}); tagging ${version} as ${tag} to preserve latest."
-  fi
-fi
 
 if [[ "$dry_run" == "true" ]]; then
   echo "[dry-run] would publish ${pkg}@${version} (tag: ${tag}) to ${registry}"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -27,6 +27,9 @@
 #     re-running a release or the backfill is always a safe no-op.
 #   - Computes the dist-tag from the version string (beta/alpha/rc/latest) so a
 #     pre-release never moves the `latest` pointer.
+#   - For a stable release whose major is older than the registry's current
+#     `latest` (e.g. a 5.x patch shipped after 6.x), tags it `v<major>-latest`
+#     instead of `latest`, so `latest` never moves backwards onto an old major.
 set -euo pipefail
 
 dry_run="${DRY_RUN:-false}"
@@ -55,6 +58,20 @@ esac
 if npm view "${pkg}@${version}" version --registry "$registry" >/dev/null 2>&1; then
   echo "Version ${pkg}@${version} already on ${registry}, skipping."
   exit 0
+fi
+
+# Don't let a stable release move `latest` backwards onto an older major. If the
+# registry's current `latest` is already a newer major than this version, publish
+# under `v<major>-latest` instead. (Only reached when actually publishing, so the
+# extra lookup is skipped for no-op re-runs above.)
+if [[ "$tag" == "latest" ]]; then
+  current_latest=$(npm view "${pkg}" version --registry "$registry" 2>/dev/null || true)
+  our_major=${version%%.*}
+  latest_major=${current_latest%%.*}
+  if [[ "$our_major" =~ ^[0-9]+$ && "$latest_major" =~ ^[0-9]+$ ]] && (( our_major < latest_major )); then
+    tag="v${our_major}-latest"
+    echo "Current latest is ${current_latest} (major ${latest_major}); tagging ${version} as ${tag} to preserve latest."
+  fi
 fi
 
 if [[ "$dry_run" == "true" ]]; then

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -12,9 +12,13 @@
 #                 of the current working directory (used by the GHR backfill).
 #
 # Env:
-#   NODE_AUTH_TOKEN  Auth token for the target registry. The caller is expected
-#                    to have configured .npmrc (e.g. via actions/setup-node) so
-#                    that @optimizely resolves to <registry-url> with this token.
+#   NODE_AUTH_TOKEN  Auth token for the target registry. The caller must have an
+#                    .npmrc entry supplying auth for <registry-url>'s host, e.g.
+#                    `//<host>/:_authToken=${NODE_AUTH_TOKEN}` (setup-node writes
+#                    this). This script passes --registry explicitly, so no
+#                    scope-to-registry routing is required (and the GHR job
+#                    intentionally does NOT route @optimizely to GHR, so that
+#                    `npm ci` still installs dependencies from npm).
 #   DRY_RUN          When "true", report what would happen (publish vs. skip)
 #                    without actually publishing.
 #

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Registry-agnostic, idempotent publish for @optimizely/react-sdk.
+#
+# Usage:
+#   scripts/publish.sh <registry-url> [tarball]
+#
+# Args:
+#   registry-url  Target registry, e.g. https://registry.npmjs.org
+#                 or https://npm.pkg.github.com
+#   tarball       Optional. When given, publishes that packed tarball instead
+#                 of the current working directory (used by the GHR backfill).
+#
+# Env:
+#   NODE_AUTH_TOKEN  Auth token for the target registry. The caller is expected
+#                    to have configured .npmrc (e.g. via actions/setup-node) so
+#                    that @optimizely resolves to <registry-url> with this token.
+#   DRY_RUN          When "true", report what would happen (publish vs. skip)
+#                    without actually publishing.
+#
+# Behavior:
+#   - Skips (exit 0) if the version already exists on the target registry, so
+#     re-running a release or the backfill is always a safe no-op.
+#   - Computes the dist-tag from the version string (beta/alpha/rc/latest) so a
+#     pre-release never moves the `latest` pointer.
+set -euo pipefail
+
+dry_run="${DRY_RUN:-false}"
+
+registry="${1:?usage: publish.sh <registry-url> [tarball]}"
+tarball="${2:-}"
+
+if [[ -n "$tarball" ]]; then
+  # Derive name/version from the tarball's own package.json so the guard matches
+  # exactly what we're about to publish (backfill of historical versions).
+  meta=$(tar -xzO -f "$tarball" package/package.json)
+  pkg=$(printf '%s' "$meta" | jq -r '.name')
+  version=$(printf '%s' "$meta" | jq -r '.version')
+else
+  pkg=$(jq -r '.name' package.json)
+  version=$(jq -r '.version' package.json)
+fi
+
+case "$version" in
+  *-beta*)  tag=beta ;;
+  *-alpha*) tag=alpha ;;
+  *-rc*)    tag=rc ;;
+  *)        tag=latest ;;
+esac
+
+if npm view "${pkg}@${version}" version --registry "$registry" >/dev/null 2>&1; then
+  echo "Version ${pkg}@${version} already on ${registry}, skipping."
+  exit 0
+fi
+
+if [[ "$dry_run" == "true" ]]; then
+  echo "[dry-run] would publish ${pkg}@${version} (tag: ${tag}) to ${registry}"
+  exit 0
+fi
+
+echo "Publishing ${pkg}@${version} (tag: ${tag}) to ${registry}"
+if [[ -n "$tarball" ]]; then
+  # The tarball is a prebuilt artifact; skip lifecycle scripts (prepublishOnly
+  # = test + build) that would otherwise run from the current package.json.
+  npm publish "$tarball" --registry "$registry" --tag "$tag" --ignore-scripts
+else
+  npm publish --registry "$registry" --tag "$tag"
+fi


### PR DESCRIPTION
## Summary
Adds GitHub Package Registry (GHR) publishing alongside the existing npm release, and a way to backfill historical versions to GHR.

Changes

- react_release.yml — on release, builds/tests/packs a single tarball once and publishes that same artifact to both npm and GHR, so both registries get identical bytes. npm publishes first; if it fails the job stops before GHR, keeping the registries in sync.
- scripts/publish.sh — shared, idempotent publish helper: skips versions already present on the target registry (safe re-runs), computes the dist-tag from the version (beta/alpha/rc/latest), and never moves latest backwards onto an older major (tags it v<major>-latest instead).
- ghr_backfill.yml — manual (workflow_dispatch) workflow to backfill any or all npm versions into GHR by re-publishing the npm tarballs. Idempotent, with a dry-run option.

### Recovery
- npm ok / GHR fails → re-run the release, or run the backfill (guard skips what's already published).
- npm fails → GHR is skipped; nothing is half-published.

## Test plan

Existing tests should pass
## Issues
- FSSDK-12882